### PR TITLE
support compute server metadata for create and get

### DIFF
--- a/examples/create-server.rs
+++ b/examples/create-server.rs
@@ -34,6 +34,7 @@ fn main() {
 
     let waiter = os.new_server(name, flavor)
         .with_image(image).with_network(network)
+        .with_metadata("key", "value")
         .create().expect("Cannot create a server");
     {
         let current = waiter.waiter_current_state();

--- a/examples/get-server.rs
+++ b/examples/get-server.rs
@@ -32,6 +32,10 @@ fn main() {
              server.id(), server.name(), server.status(), server.power_state());
     println!("Links: image = {:?}", server.image_id());
     println!("Floating IP: {:?}", server.floating_ip());
+
+    if !server.metadata().is_empty() {
+        println!("Metadata: {:?}", server.metadata());
+    }
 }
 
 #[cfg(not(feature = "compute"))]

--- a/src/compute/protocol.rs
+++ b/src/compute/protocol.rs
@@ -150,6 +150,8 @@ pub struct Server {
     #[serde(deserialize_with = "common::protocol::empty_as_none", default)]
     pub image: Option<common::protocol::Ref>,
     pub name: String,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
     pub status: ServerStatus,
     #[serde(rename = "OS-EXT-STS:power_state", default)]
     pub power_state: ServerPowerState,
@@ -188,6 +190,8 @@ pub struct ServerCreate {
     pub imageRef: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key_name: Option<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
     pub name: String,
     pub networks: Vec<ServerNetwork>
 }

--- a/src/compute/servers.rs
+++ b/src/compute/servers.rs
@@ -81,6 +81,7 @@ pub struct NewServer {
     session: Rc<Session>,
     flavor: FlavorRef,
     image: Option<ImageRef>,
+    metadata: HashMap<String, String>,
     name: String,
     networks: Vec<ServerNIC>,
 }
@@ -177,6 +178,11 @@ impl Server {
     /// Get a reference to server name.
     pub fn name(&self) -> &String {
         &self.inner.name
+    }
+
+    /// Get a reference to associated metadata.
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        &self.inner.metadata
     }
 
     /// Get server power state.
@@ -480,6 +486,7 @@ impl NewServer {
             session: session,
             flavor: flavor,
             image: None,
+            metadata: HashMap::new(),
             name: name,
             networks: Vec::new(),
         }
@@ -494,6 +501,7 @@ impl NewServer {
                 None => None
             },
             key_name: None,  // TODO
+            metadata: self.metadata,
             name: self.name,
             networks: convert_networks(&self.session, self.networks)?
         };
@@ -559,6 +567,14 @@ impl NewServer {
     pub fn with_port<P>(mut self, port: P) -> NewServer
             where P: Into<PortRef> {
         self.add_port(port);
+        self
+    }
+
+    /// Add an arbitrary key/value metadata pair.
+    pub fn with_metadata<S1, S2>(mut self, key: S1, value: S2) -> NewServer
+            where S1: Into<String>,
+                  S2: Into<String> {
+        let _ = self.metadata.insert(key.into(), value.into());
         self
     }
 }

--- a/tests/integration-create-delete-server.rs
+++ b/tests/integration-create-delete-server.rs
@@ -41,11 +41,13 @@ fn test_basic_server_ops() {
 
     let mut server = os.new_server("rust-openstack-integration", flavor_id)
         .with_image(image_id).with_network(network_id)
+        .with_metadata("meta", "a3f955c049f7416faa7")
         .create().expect("Failed to request server creation")
         .wait().expect("Server was not created");
     assert_eq!(server.name(), "rust-openstack-integration");
     assert_eq!(server.status(), openstack::compute::ServerStatus::Active);
     assert_eq!(server.power_state(), openstack::compute::ServerPowerState::Running);
+    assert_eq!(server.metadata().get("meta"), Some(&"a3f955c049f7416faa7".to_string()));
 
     server.stop().expect("Failed to request power off")
         .wait().expect("Failed to power off");


### PR DESCRIPTION
Adds support for assigning metadata key/value pairs in ServerCreate, as well as
exposing existing metadata on the get/list side.

Metadata keys and values are always strings.

I'd be happy to throw something in the `test_basic_server_ops` test which assigned a couple metadata pairs and verified that the assigned values are present in the resulting `Server` -- I wasn't sure where test coverage for this small change would be best.