### PR TITLE
fix(network): network names are optional, change to Option<String>

### DIFF
--- a/examples/create-delete-port.rs
+++ b/examples/create-delete-port.rs
@@ -32,7 +32,7 @@ fn display_port(port: &openstack::network::Port) {
         println!("* IP = {}, Subnet = {}", ip.ip_address, subnet.cidr());
     }
     let net = port.network().expect("Cannot fetch network");
-    println!("* Network: ID = {}, Name = {}", net.id(), net.name());
+    println!("* Network: ID = {}, Name = {:?}", net.id(), net.name());
 }
 
 #[cfg(feature = "network")]

--- a/examples/get-network.rs
+++ b/examples/get-network.rs
@@ -28,7 +28,7 @@ fn main() {
     let id = env::args().nth(1).expect("Provide a network ID");
     let network = os.get_network(id).expect("Cannot get an network");
 
-    println!("ID = {}, Name = {}, UP = {}, external = {:?}",
+    println!("ID = {}, Name = {:?}, UP = {}, external = {:?}",
              network.id(), network.name(), network.admin_state_up(),
              network.external());
 }

--- a/examples/list-floating-ips.rs
+++ b/examples/list-floating-ips.rs
@@ -24,7 +24,7 @@ fn display_floating_ip(floating_ip: &openstack::network::FloatingIp) {
     println!("ID = {}, IP = {}, Fixed IP = {:?}, Status = {}",
              floating_ip.id(), floating_ip.floating_ip_address(),
              floating_ip.fixed_ip_address(), floating_ip.status());
-    println!("* Network = {}, Name = {}",
+    println!("* Network = {}, Name = {:?}",
              floating_ip.floating_network_id(),
              floating_ip.floating_network()
                 .expect("Cannot fetch floating network").name());

--- a/examples/list-networks.rs
+++ b/examples/list-networks.rs
@@ -27,13 +27,13 @@ fn main() {
         .expect("Failed to create an identity provider from the environment");
     let sorting = openstack::network::NetworkSortKey::Name;
 
-    let servers: Vec<openstack::network::Network> = os.find_networks()
+    let networks: Vec<openstack::network::Network> = os.find_networks()
         .sort_by(openstack::Sort::Asc(sorting))
         .into_iter().take(10).collect()
         .expect("Cannot list networks");
     println!("First 10 networks:");
-    for s in &servers {
-        println!("ID = {}, Name = {}, UP = {}",
+    for s in &networks {
+        println!("ID = {}, Name = {:?}, UP = {}",
                  s.id(), s.name(), s.admin_state_up());
     }
 }

--- a/examples/list-ports.rs
+++ b/examples/list-ports.rs
@@ -30,7 +30,7 @@ fn display_port(port: &openstack::network::Port) {
         println!("* IP = {}, Subnet = {}", ip.ip_address, subnet.cidr());
     }
     let net = port.network().expect("Cannot fetch network");
-    println!("* Network: ID = {}, Name = {}", net.id(), net.name());
+    println!("* Network: ID = {}, Name = {:?}", net.id(), net.name());
 }
 
 #[cfg(feature = "network")]

--- a/examples/list-subnets.rs
+++ b/examples/list-subnets.rs
@@ -24,7 +24,7 @@ fn display_subnet(subnet: &openstack::network::Subnet) {
     println!("ID = {}, CIDR = {}, Gateway = {:?}, DHCP? {}",
              subnet.id(), subnet.cidr(), subnet.gateway_ip(), subnet.dhcp_enabled());
     let net = subnet.network().expect("Cannot fetch network");
-    println!("* Network: ID = {}, Name = {}", net.id(), net.name());
+    println!("* Network: ID = {}, Name = {:?}", net.id(), net.name());
 }
 
 #[cfg(feature = "network")]

--- a/src/network/networks.rs
+++ b/src/network/networks.rs
@@ -121,7 +121,7 @@ impl Network {
 
     transparent_property! {
         #[doc = "Network name."]
-        name: ref String
+        name: ref Option<String>
     }
 
     transparent_property! {
@@ -281,7 +281,7 @@ impl NewNetwork {
 
     creation_inner_field! {
         #[doc = "Set a name for the network."]
-        set_name, with_name -> name
+        set_name, with_name -> name: optional String
     }
 
     creation_inner_field! {

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -146,8 +146,9 @@ pub struct Network {
     pub l2_adjacency: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mtu: Option<u32>,
-    #[serde(skip_serializing_if = "String::is_empty")]
-    pub name: String,
+    #[serde(deserialize_with = "common::protocol::empty_as_none",
+            skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub port_security_enabled: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -175,7 +176,7 @@ impl Default for Network {
             is_default: None,
             l2_adjacency: None,
             mtu: None,
-            name: String::new(),
+            name: None,
             port_security_enabled: None,
             project_id: None,
             shared: false,

--- a/tests/integration-network-crud.rs
+++ b/tests/integration-network-crud.rs
@@ -87,6 +87,7 @@ fn test_network_create_delete_simple() {
     assert!(network.dns_domain().is_none());
     assert_eq!(network.external(), Some(false));
     assert!(!network.shared());
+    assert!(network.name().is_none());
 
     network.delete().expect("Cannot request network deletion")
         .wait().expect("Network was not deleted");
@@ -106,7 +107,7 @@ fn test_network_create_delete_with_fields() {
     assert!(network.dns_domain().is_none());
     assert_eq!(network.external(), Some(false));
     assert!(!network.shared());
-    assert_eq!(network.name(), "rust-openstack-integration-new");
+    assert_eq!(network.name().as_ref().unwrap(), "rust-openstack-integration-new");
 
     network.delete().expect("Cannot request network deletion")
         .wait().expect("Network was not deleted");


### PR DESCRIPTION
BREAKING CHANGE:
    Return type of `Network::name` is now `Option<String>` instead of `String`.