### PR TITLE
feat: update to reqwest 0.9 (some breaking changes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ eui48 = { version = "^0.3.1", features = ["serde"] }
 fallible-iterator = "^0.1"
 ipnet = { version = "^2.0", features = ["serde"] }
 log = "^0.4"
-reqwest = "^0.8.4"
+reqwest = "^0.9"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"

--- a/src/auth/base.rs
+++ b/src/auth/base.rs
@@ -16,10 +16,9 @@
 
 use std::fmt::Debug;
 
-use reqwest::{Method, Url};
+use reqwest::{Method, RequestBuilder, Url};
 
 use super::super::Result;
-use super::super::session::RequestBuilder;
 
 
 /// Trait for an authentication method.

--- a/src/auth/simple.rs
+++ b/src/auth/simple.rs
@@ -14,10 +14,9 @@
 
 //! Simple authentication methods.
 
-use reqwest::{Client, IntoUrl, Method, Url, UrlError};
+use reqwest::{Client, IntoUrl, Method, RequestBuilder, Url};
 
 use super::super::Result;
-use super::super::session::RequestBuilder;
 use super::AuthMethod;
 
 /// Authentication method that provides no authentication.
@@ -35,8 +34,7 @@ impl NoAuth {
     ///
     /// This endpoint will be returned in response to all get_endpoint calls
     /// of the [AuthMethod](trait.AuthMethod.html) trait.
-    pub fn new<U>(endpoint: U) -> ::std::result::Result<NoAuth, UrlError>
-            where U: IntoUrl {
+    pub fn new<U>(endpoint: U) -> Result<NoAuth> where U: IntoUrl {
         Ok(NoAuth {
             client: Client::new(),
             endpoint: endpoint.into_url()?
@@ -47,7 +45,7 @@ impl NoAuth {
 impl AuthMethod for NoAuth {
     /// Create a request.
     fn request(&self, method: Method, url: Url) -> Result<RequestBuilder> {
-        Ok(RequestBuilder::new(self.client.request(method, url)))
+        Ok(self.client.request(method, url))
     }
 
     /// Get a predefined endpoint for all service types

--- a/src/common/protocol.rs
+++ b/src/common/protocol.rs
@@ -28,7 +28,7 @@ use serde_json;
 
 use super::super::{Error, ErrorKind, Result};
 use super::super::auth::AuthMethod;
-use super::super::session::ServiceType;
+use super::super::session::{RequestBuilderExt, ServiceType};
 use super::super::utils;
 use super::ApiVersion;
 
@@ -119,7 +119,7 @@ impl ServiceInfo {
         // accessed via HTTP
         let secure = endpoint.scheme() == "https";
 
-        let result = auth.request(Method::Get, endpoint.clone())?.send();
+        let result = auth.request(Method::GET, endpoint.clone())?.send_checked();
         match result {
             Ok(mut resp) => {
                 let mut info = match resp.json()? {

--- a/src/error.rs
+++ b/src/error.rs
@@ -194,11 +194,11 @@ impl From<HttpClientError> for Error {
     fn from(value: HttpClientError) -> Error {
         let msg = value.to_string();
         let kind = match value.status() {
-            Some(StatusCode::Unauthorized) => ErrorKind::AuthenticationFailed,
-            Some(StatusCode::Forbidden) => ErrorKind::AccessDenied,
-            Some(StatusCode::NotFound) => ErrorKind::ResourceNotFound,
-            Some(StatusCode::NotAcceptable) => ErrorKind::IncompatibleApiVersion,
-            Some(StatusCode::Conflict) => ErrorKind::Conflict,
+            Some(StatusCode::UNAUTHORIZED) => ErrorKind::AuthenticationFailed,
+            Some(StatusCode::FORBIDDEN) => ErrorKind::AccessDenied,
+            Some(StatusCode::NOT_FOUND) => ErrorKind::ResourceNotFound,
+            Some(StatusCode::NOT_ACCEPTABLE) => ErrorKind::IncompatibleApiVersion,
+            Some(StatusCode::CONFLICT) => ErrorKind::Conflict,
             Some(c) if c.is_client_error() => ErrorKind::InvalidInput,
             Some(c) if c.is_server_error() => ErrorKind::InternalServerError,
             None => ErrorKind::ProtocolError,


### PR DESCRIPTION
Taking this opportunity to rely less on the exact reqwest API.

BREAKING CHANGES:
* Custom `RequestBuilder` is removed in favor of `RequestBuilderExt`
  extension trait on top of `reqwest::RequestBuilder`.
* `AuthMethod::request` and `Session::request` now return
  `Result<RequestBuilder>` with `RequestBuilder` from `reqwest`.
* `Identity::new` and `NoAuth::new` now return the `Result` (using
   `openstack::Error` as the error type).
* Changed `ServiceType::api_version_headers` to `set_api_version_headers`
  to stop using `reqwest` headers type in the signature.