### PR TITLE
chore(auth): make from_env and from_config return Session (#9)

### DIFF
--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -23,6 +23,7 @@ use serde_yaml;
 
 use super::Password;
 use super::super::{Error, ErrorKind, Result};
+use super::super::session::Session;
 
 #[derive(Debug, Clone, Deserialize)]
 struct Auth {
@@ -80,8 +81,8 @@ fn find_config() -> Option<PathBuf> {
     }
 }
 
-/// Create `Identity` authentication from the config file.
-pub fn from_config<S: AsRef<str>>(cloud_name: S) -> Result<Password> {
+/// Create a `Session` from the config file.
+pub fn from_config<S: AsRef<str>>(cloud_name: S) -> Result<Session> {
     let path = find_config()
         .ok_or_else(|| Error::new(ErrorKind::InvalidConfig,
                                   "clouds.yaml was not found in any location"))?;
@@ -106,5 +107,5 @@ pub fn from_config<S: AsRef<str>>(cloud_name: S) -> Result<Password> {
         id.set_region(region)
     }
 
-    Ok(id)
+    Ok(Session::new(id))
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -50,13 +50,13 @@
 //! let os = openstack::Cloud::new(auth);
 //! ```
 //!
-//! Creating an authentication method from environment variables:
+//! Creating a session and a cloud from environment variables:
 //!
 //! ```rust,no_run
 //! use openstack;
 //!
-//! let auth = openstack::auth::from_env().expect("Failed to authenticate");
-//! let os = openstack::Cloud::new(auth);
+//! let session = openstack::auth::from_env().expect("Failed to authenticate");
+//! let os = openstack::Cloud::from(session);
 //! ```
 //!
 //! Creating a dummy authentication method for use against clouds that do not
@@ -87,6 +87,7 @@ pub use self::identity::{Identity, Password};
 use std::env;
 
 use super::{Error, ErrorKind, Result};
+use super::session::Session;
 
 const MISSING_ENV_VARS: &str =
     "Not all required environment variables were provided";
@@ -94,14 +95,13 @@ const MISSING_ENV_VARS: &str =
 #[inline]
 fn _get_env(name: &str) -> Result<String> {
     env::var(name).map_err(|_| {
-        Error::new(ErrorKind::InvalidInput,
-                                MISSING_ENV_VARS)
+        Error::new(ErrorKind::InvalidInput, MISSING_ENV_VARS)
     })
 }
 
 
-/// Create an authentication method from environment variables.
-pub fn from_env() -> Result<Password> {
+/// Create a `Session` from environment variables.
+pub fn from_env() -> Result<Session> {
     if let Ok(cloud_name) = env::var("OS_CLOUD") {
         from_config(cloud_name)
     } else {
@@ -117,6 +117,6 @@ pub fn from_env() -> Result<Password> {
         let project_domain = env::var("OS_PROJECT_DOMAIN_NAME")
             .unwrap_or(String::from("Default"));
 
-        Ok(id.with_project_scope(project_name, project_domain))
+        Ok(Session::new(id.with_project_scope(project_name, project_domain)))
     }
 }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -52,19 +52,42 @@ impl Cloud {
     /// # Example
     ///
     /// ```rust,no_run
-    /// fn cloud_from_env() -> openstack::Result<openstack::Cloud> {
-    ///     openstack::auth::from_env().map(openstack::Cloud::new)
+    /// fn cloud() -> openstack::Result<openstack::Cloud> {
+    ///     let auth = openstack::auth::Password::new(
+    ///             "https://cloud.example.com",
+    ///             "user1", "pa$$word", "Default")
+    ///         .expect("Invalid authentication URL")
+    ///         .with_project_scope("project1", "Default");
+    ///     Ok(openstack::Cloud::new(auth))
     /// }
     ///
-    /// # fn main() { cloud_from_env().unwrap(); }
+    /// # fn main() { cloud().unwrap(); }
     /// ```
     ///
-    /// Note: in this particular case it's better to use
-    /// [from_env](#method.from_env).
+    /// # See Also
+    ///
+    /// * [from_config](#method.from_config) to create a Cloud from clouds.yaml
+    /// * [from_env](#method.from_env) to create a Cloud from environment variables
     pub fn new<Auth: AuthMethod + 'static>(auth_method: Auth) -> Cloud {
         Cloud {
             session: Rc::new(Session::new(auth_method))
         }
+    }
+
+    /// Create a new cloud object from a configuration file
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # fn cloud_from_config() -> openstack::Result<()> {
+    /// let os = openstack::Cloud::from_config("cloud-1")?;
+    /// # Ok(()) }
+    /// # fn main() { cloud_from_config().unwrap(); }
+    /// ```
+    pub fn from_config<S: AsRef<str>>(cloud_name: S) -> Result<Cloud> {
+        Ok(Cloud {
+            session: Rc::new(auth::from_config(cloud_name)?)
+        })
     }
 
     /// Create a new cloud object from environment variables.
@@ -79,7 +102,7 @@ impl Cloud {
     /// ```
     pub fn from_env() -> Result<Cloud> {
         Ok(Cloud {
-            session: Rc::new(Session::new(auth::from_env()?))
+            session: Rc::new(auth::from_env()?)
         })
     }
 


### PR DESCRIPTION
Also add Cloud::from_config.

BREAKING CHANGES:
    `auth::from_env` and `auth::config` now return `Result<Session>`