### PR TITLE
Use rustls instead of native-tls to avoid non-Rust dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,12 @@ edition = "2018"
 
 [features]
 
-default = ["compute", "image", "network"]
+default = ["compute", "image", "network", "native-tls"]
 compute = []
 image = []
 network = []
+native-tls = ["reqwest/default-tls", "osauth/native-tls"]
+rustls = ["reqwest/rustls-tls", "osauth/rustls"]
 
 [dependencies]
 
@@ -27,9 +29,9 @@ eui48 = { version = "^0.4.0", features = ["serde"] }
 fallible-iterator = "^0.2.0"
 ipnet = { version = "^2.0", features = ["serde"] }
 log = "^0.4"
-osauth = "^0.2.3"
+osauth = { version = "^0.2.3", default-features = false, features = ["sync"] }
 osproto = "^0.1.2"
-reqwest = { version = "^0.9", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "^0.9", default-features = false }
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ eui48 = { version = "^0.4.0", features = ["serde"] }
 fallible-iterator = "^0.2.0"
 ipnet = { version = "^2.0", features = ["serde"] }
 log = "^0.4"
-reqwest = "^0.9"
 osauth = "^0.2.3"
 osproto = "^0.1.2"
+reqwest = { version = "^0.9", default-features = false, features = ["rustls-tls"] }
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"


### PR DESCRIPTION
This might need a couple of iterations before you're happy with it, but let's see.

I'm using rust-openstack in an internal tool, and I want to be able to build it into a binary with as few dependencies as possible that can run on lots of systems. Currently that's a bit painful because it depends on the system openssl library, and isn't portable between e.g. Ubuntu and Centos systems if they have slightly different OpenSSL library versions.

https://github.com/ctz/rustls is a pure-Rust HTTPS library, so avoids the system openssl dependency, and reqwest exposes a feature to use that for HTTPS instead.

`rusoto_ec2` takes an approach of exposing `rustls` and `native-tls` features so users can explicitly choose between them. I worry that would be a bit fiddlier for rust-openstack, because to switch to rustls someone would need to:

- disable default features
- re-enable the sensible defaults - compute, image and network, plus the sync feature from osauth that we'd need to re-export
- also enable the rustls feature

Given that overhead I'd like to suggest just switching to rustls by default, and only exposing a flag if some other user really wants to use native-tls - but I might be overly-focused on making my use-case easy, so you're welcome to disagree and I'll put in feature flags.