### PR TITLE
Allow setting 'shared' on NewNetwork

### DIFF
--- a/src/network/networks.rs
+++ b/src/network/networks.rs
@@ -389,6 +389,12 @@ impl NewNetwork {
     }
 
     creation_inner_field! {
+        #[doc = "Configure whether the network is shared across all projects."]
+        set_shared, with_shared
+            -> shared: bool
+    }
+
+    creation_inner_field! {
         #[doc = "Configure VLAN transparency mode of the network."]
         set_vlan_transparent, with_vlan_transparent
             -> vlan_transparent: optional bool


### PR DESCRIPTION
The 'shared' field is present and editable in Network, but it wasn't
in NewNetwork. It is now added to NewNetwork as well to allow creation
of shared networks.