### PR TITLE
Added method to return OS-EXT-SRV-ATTR:instance_name

### DIFF
--- a/src/compute/protocol.rs
+++ b/src/compute/protocol.rs
@@ -218,8 +218,8 @@ pub struct Server {
     #[serde(rename = "updated")]
     pub updated_at: DateTime<FixedOffset>,
     pub user_id: String,
-    #[serde(rename = "OS-EXT-SRV-ATTR:instance_name")]
-    pub instance_name: String,
+    #[serde(rename = "OS-EXT-SRV-ATTR:instance_name", default)]
+    pub instance_name: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/compute/protocol.rs
+++ b/src/compute/protocol.rs
@@ -218,6 +218,8 @@ pub struct Server {
     #[serde(rename = "updated")]
     pub updated_at: DateTime<FixedOffset>,
     pub user_id: String,
+    #[serde(rename = "OS-EXT-SRV-ATTR:instance_name")]
+    pub instance_name: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/compute/servers.rs
+++ b/src/compute/servers.rs
@@ -161,7 +161,7 @@ impl Server {
 
     transparent_property! {
         #[doc = "Instance name."]
-        instance_name: ref String
+        instance_name: ref Option<String>
     }
 
     transparent_property! {

--- a/src/compute/servers.rs
+++ b/src/compute/servers.rs
@@ -160,6 +160,11 @@ impl Server {
     }
 
     transparent_property! {
+        #[doc = "Instance name."]
+        instance_name: ref String
+    }
+
+    transparent_property! {
         #[doc = "Creation date and time."]
         created_at: DateTime<FixedOffset>
     }


### PR DESCRIPTION
This PR adds a getter method for `OS-EXT-SRV-ATTR:instance_name` which is necessary if one wants to connect to the instance via `libvirt`.