### PR TITLE
Object Storage: add availability to use custom headers

### DIFF
--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -17,6 +17,7 @@
 #[allow(unused_imports)]
 use std::io;
 use std::rc::Rc;
+use std::collections::HashMap;
 
 #[allow(unused_imports)]
 use ipnet;
@@ -40,7 +41,6 @@ use super::network::{
 #[cfg(feature = "object-storage")]
 use super::object_storage::{Container, ContainerQuery, Object, ObjectQuery};
 use super::Result;
-use std::collections::HashMap;
 
 /// OpenStack cloud API.
 ///

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -15,9 +15,10 @@
 //! Cloud API.
 
 #[allow(unused_imports)]
+use std::collections::HashMap;
+#[allow(unused_imports)]
 use std::io;
 use std::rc::Rc;
-use std::collections::HashMap;
 
 #[allow(unused_imports)]
 use ipnet;

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -40,6 +40,7 @@ use super::network::{
 #[cfg(feature = "object-storage")]
 use super::object_storage::{Container, ContainerQuery, Object, ObjectQuery};
 use super::Result;
+use std::collections::HashMap;
 
 /// OpenStack cloud API.
 ///
@@ -154,6 +155,17 @@ impl Cloud {
         R: io::Read + Send + 'static,
     {
         Object::create(self.session.clone(), container, name, body)
+    }
+
+    /// Create a new object providing specified headers to the request.
+    #[cfg(feature = "object-storage")]
+    pub fn create_object_with_headers<C, Id, R>(&self, container: C, name: Id, body: R, headers: HashMap<String, String>) -> Result<Object>
+        where
+            C: Into<ContainerRef>,
+            Id: AsRef<str>,
+            R: io::Read + Send + 'static,
+    {
+        Object::create_with_headers(self.session.clone(), container, name, body, headers)
     }
 
     /// Build a query against container list.

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -159,11 +159,17 @@ impl Cloud {
 
     /// Create a new object providing specified headers to the request.
     #[cfg(feature = "object-storage")]
-    pub fn create_object_with_headers<C, Id, R>(&self, container: C, name: Id, body: R, headers: HashMap<String, String>) -> Result<Object>
-        where
-            C: Into<ContainerRef>,
-            Id: AsRef<str>,
-            R: io::Read + Send + 'static,
+    pub fn create_object_with_headers<C, Id, R>(
+        &self,
+        container: C,
+        name: Id,
+        body: R,
+        headers: HashMap<String, String>,
+    ) -> Result<Object>
+    where
+        C: Into<ContainerRef>,
+        Id: AsRef<str>,
+        R: io::Read + Send + 'static,
     {
         Object::create_with_headers(self.session.clone(), container, name, body, headers)
     }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -42,7 +42,6 @@ use super::network::{
 #[cfg(feature = "object-storage")]
 use super::object_storage::{Container, ContainerQuery, NewObject, Object, ObjectQuery};
 use super::Result;
-use std::io::Read;
 
 /// OpenStack cloud API.
 ///
@@ -154,7 +153,7 @@ impl Cloud {
     where
         C: Into<ContainerRef>,
         Id: AsRef<str>,
-        R: Read + Send + 'static,
+        R: io::Read + Send + 'static,
     {
         Object::create(self.session.clone(), container, name, body)
     }
@@ -623,7 +622,7 @@ impl Cloud {
     where
         C: Into<String>,
         O: Into<String>,
-        B: Read + Send + 'static,
+        B: io::Read + Send + 'static,
     {
         NewObject::new(
             self.session.clone(),

--- a/src/object_storage/api.rs
+++ b/src/object_storage/api.rs
@@ -15,6 +15,7 @@
 //! Foundation bits exposing the object storage API.
 
 use std::io;
+use std::collections::HashMap;
 
 use osauth::request::NO_PATH;
 use osauth::services::OBJECT_STORAGE;
@@ -25,7 +26,6 @@ use super::super::session::Session;
 use super::super::utils::Query;
 use super::super::Result;
 use super::protocol::*;
-use std::collections::HashMap;
 
 /// Create a new container.
 ///

--- a/src/object_storage/api.rs
+++ b/src/object_storage/api.rs
@@ -67,11 +67,17 @@ where
 }
 
 /// Create a new object providing specified headers into the request.
-pub fn create_object_with_headers<C, O, R>(session: &Session, container: C, object: O, body: R, headers: HashMap<String, String>) -> Result<Object>
-    where
-        C: AsRef<str>,
-        O: AsRef<str>,
-        R: io::Read + Send + 'static,
+pub fn create_object_with_headers<C, O, R>(
+    session: &Session,
+    container: C,
+    object: O,
+    body: R,
+    headers: HashMap<String, String>,
+) -> Result<Object>
+where
+    C: AsRef<str>,
+    O: AsRef<str>,
+    R: io::Read + Send + 'static,
 {
     let c_id = container.as_ref();
     let o_id = object.as_ref();
@@ -79,7 +85,7 @@ pub fn create_object_with_headers<C, O, R>(session: &Session, container: C, obje
     let mut req = session.request(OBJECT_STORAGE, Method::PUT, &[c_id, o_id], None)?;
 
     // add custom headers to the request
-    for (key, val) in headers.iter(){
+    for (key, val) in headers.iter() {
         req = req.header(key, val);
     }
 
@@ -88,7 +94,6 @@ pub fn create_object_with_headers<C, O, R>(session: &Session, container: C, obje
     // We need to retrieve the size, issue HEAD.
     get_object(session, c_id, o_id)
 }
-
 
 /// Delete an empty container.
 pub fn delete_container<C>(session: &Session, container: C) -> Result<()>

--- a/src/object_storage/api.rs
+++ b/src/object_storage/api.rs
@@ -24,6 +24,7 @@ use reqwest::{Method, StatusCode};
 use super::super::session::Session;
 use super::super::utils::Query;
 use super::super::Result;
+use super::objects::ObjectHeaders;
 use super::protocol::*;
 
 /// Create a new container.
@@ -46,24 +47,32 @@ where
 }
 
 /// Create a new object.
-pub fn create_object<R>(session: &Session, object_create: ObjectCreate<R>) -> Result<Object>
+pub fn create_object<C, O, R>(
+    session: &Session,
+    container: C,
+    object: O,
+    body: R,
+    headers: ObjectHeaders,
+) -> Result<Object>
 where
+    C: AsRef<str>,
+    O: AsRef<str>,
     R: io::Read + Send + 'static,
 {
-    let c_id = object_create.c_name;
-    let o_id = object_create.name;
+    let c_id = container.as_ref();
+    let o_id = object.as_ref();
     debug!("Creating object {} in container {}", o_id, c_id);
     let mut req = session.request(OBJECT_STORAGE, Method::PUT, &[&c_id, &o_id], None)?;
 
-    if object_create.delete_after.is_some() {
-        req = req.header("X-Delete-After", object_create.delete_after.unwrap());
+    if headers.delete_after.is_some() {
+        req = req.header("X-Delete-After", headers.delete_after.unwrap());
     }
 
-    if object_create.delete_at.is_some() {
-        req = req.header("X-Delete-At", object_create.delete_at.unwrap());
+    if headers.delete_at.is_some() {
+        req = req.header("X-Delete-At", headers.delete_at.unwrap().timestamp());
     }
 
-    let _ = session.send_checked(req.body(SyncBody::new(object_create.body)))?;
+    let _ = session.send_checked(req.body(SyncBody::new(body)))?;
     debug!("Successfully created object {} in container {}", o_id, c_id);
     // We need to retrieve the size, issue HEAD.
     get_object(session, c_id, o_id)

--- a/src/object_storage/api.rs
+++ b/src/object_storage/api.rs
@@ -14,8 +14,8 @@
 
 //! Foundation bits exposing the object storage API.
 
-use std::io;
 use std::collections::HashMap;
+use std::io;
 
 use osauth::request::NO_PATH;
 use osauth::services::OBJECT_STORAGE;

--- a/src/object_storage/mod.rs
+++ b/src/object_storage/mod.rs
@@ -20,4 +20,4 @@ mod objects;
 mod protocol;
 
 pub use containers::{Container, ContainerQuery};
-pub use objects::{Object, ObjectQuery};
+pub use objects::{NewObject, Object, ObjectQuery};

--- a/src/object_storage/objects.rs
+++ b/src/object_storage/objects.rs
@@ -26,6 +26,7 @@ use super::super::session::Session;
 use super::super::utils::Query;
 use super::super::{Error, Result};
 use super::{api, protocol};
+use std::collections::HashMap;
 
 /// A query to objects.
 #[derive(Clone, Debug)]
@@ -69,6 +70,25 @@ impl Object {
         let c_ref = container.into();
         let c_name = c_ref.to_string();
         let inner = api::create_object(&session, c_ref, name, body)?;
+        Ok(Object::new(session, inner, c_name))
+    }
+
+    /// Create an object with headers sent with the request.
+    pub(crate) fn create_with_headers<C, Id, R>(
+        session: Rc<Session>,
+        container: C,
+        name: Id,
+        body: R,
+        headers: HashMap<String, String>
+    ) -> Result<Object>
+        where
+            C: Into<ContainerRef>,
+            Id: AsRef<str>,
+            R: Read + Send + 'static,
+    {
+        let c_ref = container.into();
+        let c_name = c_ref.to_string();
+        let inner = api::create_object_with_headers(&session, c_ref, name, body, headers)?;
         Ok(Object::new(session, inner, c_name))
     }
 

--- a/src/object_storage/objects.rs
+++ b/src/object_storage/objects.rs
@@ -14,9 +14,9 @@
 
 //! Stored objects.
 
+use std::collections::HashMap;
 use std::io::Read;
 use std::rc::Rc;
-use std::collections::HashMap;
 
 use fallible_iterator::{FallibleIterator, IntoFallibleIterator};
 

--- a/src/object_storage/objects.rs
+++ b/src/object_storage/objects.rs
@@ -16,6 +16,7 @@
 
 use std::io::Read;
 use std::rc::Rc;
+use std::collections::HashMap;
 
 use fallible_iterator::{FallibleIterator, IntoFallibleIterator};
 
@@ -26,7 +27,6 @@ use super::super::session::Session;
 use super::super::utils::Query;
 use super::super::{Error, Result};
 use super::{api, protocol};
-use std::collections::HashMap;
 
 /// A query to objects.
 #[derive(Clone, Debug)]

--- a/src/object_storage/objects.rs
+++ b/src/object_storage/objects.rs
@@ -79,12 +79,12 @@ impl Object {
         container: C,
         name: Id,
         body: R,
-        headers: HashMap<String, String>
+        headers: HashMap<String, String>,
     ) -> Result<Object>
-        where
-            C: Into<ContainerRef>,
-            Id: AsRef<str>,
-            R: Read + Send + 'static,
+    where
+        C: Into<ContainerRef>,
+        Id: AsRef<str>,
+        R: Read + Send + 'static,
     {
         let c_ref = container.into();
         let c_name = c_ref.to_string();

--- a/src/object_storage/protocol.rs
+++ b/src/object_storage/protocol.rs
@@ -39,6 +39,14 @@ pub struct Object {
     pub name: String,
 }
 
+pub struct ObjectCreate<R> {
+    pub name: String,
+    pub c_name: String,
+    pub body: R,
+    pub delete_after: Option<u32>,
+    pub delete_at: Option<i64>,
+}
+
 impl Container {
     pub fn from_headers(name: &str, value: &HeaderMap) -> Result<Container, Error> {
         let bytes_header = HeaderName::from_static("x-container-bytes-used");

--- a/src/object_storage/protocol.rs
+++ b/src/object_storage/protocol.rs
@@ -39,14 +39,6 @@ pub struct Object {
     pub name: String,
 }
 
-pub struct ObjectCreate<R> {
-    pub name: String,
-    pub c_name: String,
-    pub body: R,
-    pub delete_after: Option<u32>,
-    pub delete_at: Option<i64>,
-}
-
 impl Container {
     pub fn from_headers(name: &str, value: &HeaderMap) -> Result<Container, Error> {
         let bytes_header = HeaderName::from_static("x-container-bytes-used");


### PR DESCRIPTION
First I want to thank you for your lib.

I add the availibitily to send custom headers during an object creation. This allows for exemple to use 'X-Delete-After' for adding a ttl to the object.
I choose to send headers, this way there is more flexibility and everyone can use the headers he wants based on the openstack doc.

I just start developping in rust from few days, so I didn't publish tests with it (though I have tested it with a personnal project). Also feel free to give me some comments and I will be glad to improve it.