### PR TITLE
Add url method to Object

### DIFF
--- a/src/object_storage/objects.rs
+++ b/src/object_storage/objects.rs
@@ -19,6 +19,8 @@ use std::rc::Rc;
 
 use fallible_iterator::{FallibleIterator, IntoFallibleIterator};
 
+use osauth::services::OBJECT_STORAGE;
+
 use super::super::common::{
     ContainerRef, IntoVerified, ObjectRef, Refresh, ResourceIterator, ResourceQuery,
 };
@@ -26,6 +28,7 @@ use super::super::session::Session;
 use super::super::utils::Query;
 use super::super::{Error, Result};
 use super::{api, protocol};
+use reqwest::Url;
 
 /// A query to objects.
 #[derive(Clone, Debug)]
@@ -107,6 +110,13 @@ impl Object {
     #[inline]
     pub fn container_name(&self) -> &String {
         &self.c_name
+    }
+
+    /// Object url
+    #[inline]
+    pub fn url(&self) -> Result<Url> {
+        self.session
+            .get_endpoint(OBJECT_STORAGE, &[self.container_name(), self.name()])
     }
 
     transparent_property! {

--- a/src/object_storage/objects.rs
+++ b/src/object_storage/objects.rs
@@ -18,8 +18,8 @@ use std::io::Read;
 use std::rc::Rc;
 
 use fallible_iterator::{FallibleIterator, IntoFallibleIterator};
-
 use osauth::services::OBJECT_STORAGE;
+use reqwest::Url;
 
 use super::super::common::{
     ContainerRef, IntoVerified, ObjectRef, Refresh, ResourceIterator, ResourceQuery,
@@ -28,7 +28,6 @@ use super::super::session::Session;
 use super::super::utils::Query;
 use super::super::{Error, Result};
 use super::{api, protocol};
-use reqwest::Url;
 
 /// A query to objects.
 #[derive(Clone, Debug)]
@@ -112,13 +111,6 @@ impl Object {
         &self.c_name
     }
 
-    /// Object url
-    #[inline]
-    pub fn url(&self) -> Result<Url> {
-        self.session
-            .get_endpoint(OBJECT_STORAGE, &[self.container_name(), self.name()])
-    }
-
     transparent_property! {
         #[doc = "Object content type (if set)."]
         content_type: ref Option<String>
@@ -127,6 +119,13 @@ impl Object {
     transparent_property! {
         #[doc = "Object name."]
         name: ref String
+    }
+
+    /// Object url.
+    #[inline]
+    pub fn url(&self) -> Result<Url> {
+        self.session
+            .get_endpoint(OBJECT_STORAGE, &[self.container_name(), self.name()])
     }
 }
 


### PR DESCRIPTION
Add a method for retreiving object url, because when creating an object (in object storage) there was no way to retreive the url.

As stated in my previous pull request, I begin in rust and would appreciate any comments to improve the pull request.