### PR TITLE
[Object store] add hash to objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ waiter = "^0.1"
 
 [dev-dependencies]
 env_logger = "^0.7"
+md-5 = "^0.9"
+hex = "^0.4"
 
 [lib]
 

--- a/examples/list-containers.rs
+++ b/examples/list-containers.rs
@@ -1,0 +1,41 @@
+// Copyright 2018 Dmitry Tantsur <divius.inside@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate env_logger;
+extern crate openstack;
+
+#[cfg(feature = "object-storage")]
+fn main() {
+    env_logger::init();
+
+    let os = openstack::Cloud::from_env()
+        .expect("Failed to create an identity provider from the environment");
+
+    let containers: Vec<openstack::object_storage::Container> =
+        os.list_containers().expect("Cannot list containers");
+    println!("Containers:");
+    for container in &containers {
+        println!(
+            "Name = {}, Bytes = {}, Number of objects = {}",
+            container.name(),
+            container.bytes(),
+            container.object_count()
+        );
+    }
+}
+
+#[cfg(not(feature = "object-storage"))]
+fn main() {
+    panic!("This example cannot run with 'object-storage' feature disabled");
+}

--- a/examples/list-objects.rs
+++ b/examples/list-objects.rs
@@ -40,9 +40,10 @@ fn main() {
 
     println!("first 10 objects");
     for o in objects {
-        println!("Name = {}, Bytes = {}",
+        println!("Name = {}, Bytes = {}, Hash = {}",
             o.name(),
             o.bytes(),
+            o.hash(),
         );
     }
 }

--- a/examples/list-objects.rs
+++ b/examples/list-objects.rs
@@ -43,7 +43,7 @@ fn main() {
         println!("Name = {}, Bytes = {}, Hash = {}",
             o.name(),
             o.bytes(),
-            o.hash(),
+            o.hash().as_ref().unwrap_or(&String::from("")),
         );
     }
 }

--- a/examples/list-objects.rs
+++ b/examples/list-objects.rs
@@ -1,0 +1,53 @@
+// Copyright 2018 Dmitry Tantsur <divius.inside@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate env_logger;
+extern crate openstack;
+
+use std::env;
+
+#[cfg(feature = "object-storage")]
+fn main() {
+    env_logger::init();
+
+    let os = openstack::Cloud::from_env()
+        .expect("Failed to create an identity provider from the environment");
+
+    let container_name = env::args().nth(1).expect("Provide a container name");
+    let container = os.get_container(&container_name).expect("Cannot get a container");
+
+    println!("Found container with Name = {}, Number of object = {}",
+        container.name(),
+        container.object_count()
+    );
+
+    let objects: Vec<openstack::object_storage::Object> = container
+        .find_objects()
+        .with_limit(10)
+        .all()
+        .expect("cannot list objects");
+
+    println!("first 10 objects");
+    for o in objects {
+        println!("Name = {}, Bytes = {}",
+            o.name(),
+            o.bytes(),
+        );
+    }
+}
+
+#[cfg(not(feature = "object-storage"))]
+fn main() {
+    panic!("This example cannot run with 'object-storage' feature disabled");
+}

--- a/src/object_storage/objects.rs
+++ b/src/object_storage/objects.rs
@@ -145,6 +145,11 @@ impl Object {
         name: ref String
     }
 
+    transparent_property! {
+        #[doc = "Object hash or ETag."]
+        hash: ref String
+    }
+
     /// Object url.
     #[inline]
     pub fn url(&self) -> Result<Url> {

--- a/src/object_storage/objects.rs
+++ b/src/object_storage/objects.rs
@@ -139,15 +139,15 @@ impl Object {
         #[doc = "Object content type (if set)."]
         content_type: ref Option<String>
     }
+    
+    transparent_property! {
+        #[doc = "Object hash or ETag, which is a content's md5 hash"]
+        hash: ref Option<String>
+    }
 
     transparent_property! {
         #[doc = "Object name."]
         name: ref String
-    }
-
-    transparent_property! {
-        #[doc = "Object hash or ETag."]
-        hash: ref String
     }
 
     /// Object url.

--- a/src/object_storage/protocol.rs
+++ b/src/object_storage/protocol.rs
@@ -37,10 +37,12 @@ pub struct Object {
     pub bytes: u64,
     pub content_type: Option<String>,
     pub name: String,
+    pub hash: String,
 }
 
 static CONTENT_LENGTH: HeaderName = header::CONTENT_LENGTH;
 static CONTENT_TYPE: HeaderName = header::CONTENT_TYPE;
+static ETAG: HeaderName = header::ETAG;
 
 impl Container {
     pub fn from_headers(name: &str, value: &HeaderMap) -> Result<Container, Error> {
@@ -81,10 +83,12 @@ impl Object {
                 )
             })?;
         let ct = protocol::get_header(value, &CONTENT_TYPE)?.map(From::from);
+        let hash = protocol::get_header(value, &ETAG)?.unwrap();
         Ok(Object {
             bytes: size,
             content_type: ct,
             name: name.into(),
+            hash: hash.into()
         })
     }
 }

--- a/src/object_storage/protocol.rs
+++ b/src/object_storage/protocol.rs
@@ -37,7 +37,7 @@ pub struct Object {
     pub bytes: u64,
     pub content_type: Option<String>,
     pub name: String,
-    pub hash: String,
+    pub hash: Option<String>,
 }
 
 static CONTENT_LENGTH: HeaderName = header::CONTENT_LENGTH;
@@ -83,12 +83,12 @@ impl Object {
                 )
             })?;
         let ct = protocol::get_header(value, &CONTENT_TYPE)?.map(From::from);
-        let hash = protocol::get_header(value, &ETAG)?.unwrap();
+        let hash = protocol::get_header(value, &ETAG)?.map(From::from);
         Ok(Object {
             bytes: size,
             content_type: ct,
             name: name.into(),
-            hash: hash.into()
+            hash: hash,
         })
     }
 }

--- a/tests/integration-object-storage.rs
+++ b/tests/integration-object-storage.rs
@@ -122,7 +122,7 @@ fn test_object_create() {
     assert_eq!(obj.name(), "test1");
     assert_eq!(obj.container_name(), name);
     assert_eq!(obj.bytes(), 5);
-    assert_eq!(String::from(obj.hash()), hex::encode(data_hash));
+    assert_eq!(obj.hash(), &Some(hex::encode(data_hash)));
 
     ctr.refresh().expect("Failed to refresh container");
     assert!(ctr.object_count() > 0);


### PR DESCRIPTION
This PR:

* add some examples about object stores: 
    * list containers, 
    * and list the first 10 objects of a given container;
* add hash to objects

## About object's hash property

The hash of an object [is described as the following](https://docs.openstack.org/api-ref/object-store/?expanded=get-object-content-and-metadata-detail#get-object-content-and-metadata):

> For objects smaller than 5 GB, this value is the MD5 checksum of the object content. The value is not quoted. For manifest objects, this value is the MD5 checksum of the concatenated string of ETag values for each of the segments in the manifest, and not the MD5 checksum of the content that was downloaded. Also the value is enclosed in double-quote characters. You are strongly recommended to compute the MD5 checksum of the response body as it is received and compare this value with the one in the ETag header. If they differ, the content was corrupted, so retry the operation.

The value is presented:

* under the "hash" key [when listing objects in a container](https://docs.openstack.org/api-ref/object-store/?expanded=get-object-content-and-metadata-detail,show-container-details-and-list-objects-detail#show-container-details-and-list-objects) (request `/v1/{account}/{container}`;
* as the `ETag` header, [when requesting a single object](https://docs.openstack.org/api-ref/object-store/?expanded=get-object-content-and-metadata-detail#get-object-content-and-metadata), (request `/v1/{account}/{container}/{object}`).

`hash` is kept for naming the property.

## Examples

This PR add examples for listing containers and objects.

