### PR TITLE
Implement server actions via an enum

### DIFF
--- a/src/compute/api.rs
+++ b/src/compute/api.rs
@@ -314,46 +314,20 @@ pub async fn list_servers_detail<Q: Serialize + Sync + Debug>(
     Ok(root.servers)
 }
 
-/// Run an action while providing some arguments.
-pub async fn server_action_with_args<S1, S2, Q>(
-    session: &Session,
-    id: S1,
-    action: S2,
-    args: Q,
-) -> Result<()>
+/// Run an action on a server.
+pub async fn server_action_with_args<S1, Q>(session: &Session, id: S1, action: Q) -> Result<()>
 where
     S1: AsRef<str>,
-    S2: AsRef<str>,
     Q: Serialize + Send + Debug,
 {
-    trace!(
-        "Running {} on server {} with args {:?}",
-        action.as_ref(),
-        id.as_ref(),
-        args
-    );
-    let mut body = HashMap::new();
-    let _ = body.insert(action.as_ref(), args);
+    trace!("Running {:?} on server {}", action, id.as_ref(),);
     let _ = session
         .post(COMPUTE, &["servers", id.as_ref(), "action"])
-        .json(&body)
+        .json(&action)
         .send()
         .await?;
-    debug!(
-        "Successfully ran {} on server {}",
-        action.as_ref(),
-        id.as_ref()
-    );
+    debug!("Successfully ran {:?} on server {}", action, id.as_ref());
     Ok(())
-}
-
-/// Run an action on the server.
-pub async fn server_simple_action<S1, S2>(session: &Session, id: S1, action: S2) -> Result<()>
-where
-    S1: AsRef<str>,
-    S2: AsRef<str>,
-{
-    server_action_with_args(session, id, action, serde_json::Value::Null).await
 }
 
 /// Whether key pair pagination is supported.

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -29,6 +29,6 @@ pub use self::protocol::{
     ServerSortKey, ServerStatus,
 };
 pub use self::servers::{
-    DetailedServerQuery, NewServer, Server, ServerCreationWaiter, ServerNIC, ServerQuery,
-    ServerStatusWaiter, ServerSummary,
+    DetailedServerQuery, NewServer, Server, ServerAction, ServerCreationWaiter, ServerNIC,
+    ServerQuery, ServerStatusWaiter, ServerSummary,
 };

--- a/src/compute/servers.rs
+++ b/src/compute/servers.rs
@@ -341,6 +341,7 @@ impl Server {
 /// An action to perform on a server.
 #[derive(Clone, Debug, Serialize)]
 #[non_exhaustive]
+#[allow(missing_copy_implementations)]
 pub enum ServerAction {
     /// Reboots a server.
     #[serde(rename = "reboot")]

--- a/src/compute/servers.rs
+++ b/src/compute/servers.rs
@@ -339,7 +339,8 @@ impl Server {
 }
 
 /// An action to perform on a server.
-#[derive(Clone, Copy, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 pub enum ServerAction {
     /// Reboots a server.
     #[serde(rename = "reboot")]

--- a/src/compute/servers.rs
+++ b/src/compute/servers.rs
@@ -31,7 +31,7 @@ use super::super::common::{
 #[cfg(feature = "image")]
 use super::super::image::Image;
 use super::super::session::Session;
-use super::super::utils::Query;
+use super::super::utils::{unit_to_null, Query};
 use super::super::waiter::{DeletionWaiter, Waiter};
 use super::super::{Error, ErrorKind, Result, Sort};
 use super::{api, protocol, BlockDevice, KeyPair};
@@ -336,13 +336,6 @@ impl Server {
     pub async fn action(&mut self, action: ServerAction) -> Result<()> {
         api::server_action_with_args(&self.session, &self.inner.id, action).await
     }
-}
-
-/// Serialize an enum unit variant into a None
-/// This is used to turn [ServerAction::Start] into
-/// `"os-start": null` instead of just `"os-start"`
-fn unit_to_null<S: serde::Serializer>(s: S) -> std::result::Result<S::Ok, S::Error> {
-    s.serialize_none()
 }
 
 /// An action to perform on a server.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -233,6 +233,13 @@ where
     }
 }
 
+/// Serialize an enum unit variant into a None
+/// This is used to turn [ServerAction::Start] into
+/// `"os-start": null` instead of just `"os-start"`
+pub fn unit_to_null<S: Serializer>(s: S) -> std::result::Result<S::Ok, S::Error> {
+    s.serialize_none()
+}
+
 pub mod url {
     //! Handy primitives for working with URLs.
 


### PR DESCRIPTION
This moves the server actions to use a typed enum to represent the possible actions that can be performed on a server.

In the future, I wouldn't expect that [every single action](https://docs.openstack.org/api-ref/compute/#servers-run-an-action-servers-action) would have a special method associated with it, so I opted for a generic `action` method which takes the new enum as an argument.

This now allows you to do:
```rust
server.action(ServerAction::Stop).await?
server.action(ServerAction::Reboot {reboot_type: Soft}).await?
```
which is equivalent to (the still-present)
```rust
server.stop().await?
server.reboot(Soft).await?
```

This is more verbose but will make it easier to implement the rest of the actions in the future as I would like to add the `createImage` action next, but I wanted to do the refactor separately first.

I'm happy to take feedback on API and code structure, or of you think there's another way to implement it. For example, if you think that you'd rather have each future-implemented action done as a `Server` method then this new approach gains less. Also, if the definition of the `ServerAction` enum or `unit_to_null` function make more sense in another file, I'm happy to move them.