### PR TITLE
Add 'Rebuild' to ServerStatus enum

### DIFF
--- a/src/compute/protocol.rs
+++ b/src/compute/protocol.rs
@@ -72,6 +72,7 @@ protocol_enum! {
         Migrating = "MIGRATING",
         Paused = "PAUSED",
         Rebooting = "REBOOT",
+        Rebuild = "REBUILD",
         Resizing = "RESIZE",
         RevertingResize = "REVERT_RESIZE",
         ShutOff = "SHUTOFF",


### PR DESCRIPTION
When performing a detailed server query against a cloud with VMs in state `Rebuild` we get
```
Error { kind: ProtocolError, message: "error decoding response body: Unexpected ServerStatus: REBUILD at line 1 column 46882", status: None }
```
from Serde. This PR fixes the error by adding a `Rebuild` status to the `ServerStatus` enum.