### PR TITLE
chore(ci): bump MSRV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, nightly, 1.64.0]
+        rust: [stable, nightly, 1.65.0]
         flags:
           - ""
           - "--no-default-features"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 keywords = ["api", "cloud", "openstack"]
 categories = ["api-bindings"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [features]
 default = ["compute", "image", "network", "native-tls", "object-storage"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //!
 //! # Requirements
 //!
-//! This crate requires Rust 2022 edition and rustc version 1.64.0 or newer.
+//! This crate requires Rust 2022 edition and rustc version 1.65.0 or newer.
 
 #![crate_name = "openstack"]
 #![crate_type = "lib"]


### PR DESCRIPTION
We have some CI jobs failing due to the version of `regex` we have requiring Rust 1.65.