### PR TITLE
feat(compute): rework the server's flavor field handling (closes #146)

### DIFF
--- a/examples/get-server.rs
+++ b/examples/get-server.rs
@@ -34,11 +34,10 @@ async fn main() {
         server.power_state()
     );
     println!("Links: image = {:?}", server.image_id());
+    let flavor = server.flavor().await.expect("Cannot get the flavor");
     println!(
         "Flavor: {} CPU, disk {}G, memory {}M",
-        server.flavor().vcpu_count,
-        server.flavor().root_size,
-        server.flavor().ram_size
+        flavor.vcpu_count, flavor.root_size, flavor.ram_size
     );
     println!("Floating IP: {:?}", server.floating_ip());
 

--- a/src/compute/protocol.rs
+++ b/src/compute/protocol.rs
@@ -141,22 +141,35 @@ pub struct ExtraSpecsRoot {
 }
 
 /// A summary information of a flavor used for a server.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ServerFlavor {
     /// Ephemeral disk size in GiB.
+    #[serde(rename = "ephemeral")]
     pub ephemeral_size: u64,
     /// Extra specs (if present).
+    #[serde(default)]
     pub extra_specs: Option<HashMap<String, String>>,
     /// Name of the original flavor.
     pub original_name: String,
     /// RAM size in MiB.
+    #[serde(rename = "ram")]
     pub ram_size: u64,
     /// Root disk size in GiB.
+    #[serde(rename = "disk")]
     pub root_size: u64,
     /// Swap disk size in MiB.
+    #[serde(rename = "swap")]
     pub swap_size: u64,
     /// VCPU count.
+    #[serde(rename = "vcpus")]
     pub vcpu_count: u32,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum AnyFlavor {
+    New(ServerFlavor),
+    Old(Ref),
 }
 
 fn bool_from_config_drive_string<'de, D>(deserializer: D) -> Result<bool, D::Error>
@@ -197,8 +210,7 @@ pub struct Server {
     pub created_at: DateTime<FixedOffset>,
     #[serde(deserialize_with = "empty_as_default", default)]
     pub description: Option<String>,
-    // TODO(dtantsur): flavor in newer versions
-    pub flavor: Ref,
+    pub flavor: AnyFlavor,
     #[serde(
         deserialize_with = "bool_from_config_drive_string",
         rename = "config_drive"

--- a/tests/integration-create-delete-server.rs
+++ b/tests/integration-create-delete-server.rs
@@ -98,7 +98,7 @@ async fn validate_server(os: &openstack::Cloud, server: &mut openstack::compute:
     let image = server.image().await.expect("Cannot fetch Server image");
     assert_eq!(image.id(), server.image_id().unwrap());
 
-    let flavor = server.flavor();
+    let flavor = server.flavor().await.expect("Cannot fetch Server flavor");
     assert!(flavor.vcpu_count > 0);
     assert!(flavor.ram_size > 0);
     assert!(flavor.root_size > 0);


### PR DESCRIPTION
BREAKING CHANGE
    Changes the signature of Server.flavor()
