### PR TITLE
Add Block Storage API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2021"
 rust-version = "1.65"
 
 [features]
-default = ["compute", "image", "network", "native-tls", "object-storage"]
+default = ["block-storage", "compute", "image", "network", "native-tls", "object-storage"]
+block-storage = []
 compute = []
 image = []
 network = []

--- a/src/block_storage/api.rs
+++ b/src/block_storage/api.rs
@@ -1,0 +1,15 @@
+// Copyright 2024 Sandro-Alessio Gierens <sandro@gierens.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Foundation bits exposing the Block Storage API.

--- a/src/block_storage/api.rs
+++ b/src/block_storage/api.rs
@@ -90,3 +90,16 @@ pub async fn list_volumes<Q: Serialize + Sync + Debug>(
     trace!("Received volumes: {:?}", root.volumes);
     Ok(root.volumes)
 }
+
+/// Create a volume.
+pub async fn create_volume(session: &Session, request: VolumeCreate) -> Result<Volume> {
+    debug!("Creating a volume with {:?}", request);
+    let body = VolumeCreateRoot { volume: request };
+    let root: VolumeRoot = session
+        .post(BLOCK_STORAGE, &["volumes"])
+        .json(&body)
+        .fetch()
+        .await?;
+    trace!("Requested creation of volume {:?}", root.volume);
+    Ok(root.volume)
+}

--- a/src/block_storage/api.rs
+++ b/src/block_storage/api.rs
@@ -25,6 +25,17 @@ use super::super::utils;
 use super::protocol::*;
 use super::super::Result;
 
+/// Delete a volume.
+pub async fn delete_volume<S: AsRef<str>>(session: &Session, id: S) -> Result<()> {
+    trace!("Deleting volume {}", id.as_ref());
+    let _ = session
+        .delete(BLOCK_STORAGE, &["volumes", id.as_ref()])
+        .send()
+        .await?;
+    debug!("Successfully requested deletion of volume {}", id.as_ref());
+    Ok(())
+}
+
 /// Get an volume.
 pub async fn get_volume<S: AsRef<str>>(session: &Session, id_or_name: S) -> Result<Volume> {
     let s = id_or_name.as_ref();

--- a/src/block_storage/api.rs
+++ b/src/block_storage/api.rs
@@ -22,8 +22,8 @@ use serde::Serialize;
 
 use super::super::session::Session;
 use super::super::utils;
-use super::protocol::*;
 use super::super::Result;
+use super::protocol::*;
 
 /// Delete a volume.
 pub async fn delete_volume<S: AsRef<str>>(session: &Session, id: S) -> Result<()> {
@@ -51,7 +51,10 @@ pub async fn get_volume<S: AsRef<str>>(session: &Session, id_or_name: S) -> Resu
 /// Get an volume by its ID.
 pub async fn get_volume_by_id<S: AsRef<str>>(session: &Session, id: S) -> Result<Volume> {
     trace!("Fetching volume {}", id.as_ref());
-    let root: VolumeRoot = session.get(BLOCK_STORAGE, &["volumes", id.as_ref()]).fetch().await?;
+    let root: VolumeRoot = session
+        .get(BLOCK_STORAGE, &["volumes", id.as_ref()])
+        .fetch()
+        .await?;
     trace!("Received {:?}", root.volume);
     Ok(root.volume)
 }
@@ -79,7 +82,11 @@ pub async fn list_volumes<Q: Serialize + Sync + Debug>(
     query: &Q,
 ) -> Result<Vec<Volume>> {
     trace!("Listing volumes with {:?}", query);
-    let root: VolumesRoot = session.get(BLOCK_STORAGE, &["volumes", "detail"]).query(query).fetch().await?;
+    let root: VolumesRoot = session
+        .get(BLOCK_STORAGE, &["volumes", "detail"])
+        .query(query)
+        .fetch()
+        .await?;
     trace!("Received volumes: {:?}", root.volumes);
     Ok(root.volumes)
 }

--- a/src/block_storage/api.rs
+++ b/src/block_storage/api.rs
@@ -61,3 +61,14 @@ pub async fn get_volume_by_name<S: AsRef<str>>(session: &Session, name: S) -> Re
     trace!("Received {:?}", result);
     Ok(result)
 }
+
+/// List volumes.
+pub async fn list_volumes<Q: Serialize + Sync + Debug>(
+    session: &Session,
+    query: &Q,
+) -> Result<Vec<Volume>> {
+    trace!("Listing volumes with {:?}", query);
+    let root: VolumesRoot = session.get(BLOCK_STORAGE, &["volumes", "detail"]).query(query).fetch().await?;
+    trace!("Received volumes: {:?}", root.volumes);
+    Ok(root.volumes)
+}

--- a/src/block_storage/mod.rs
+++ b/src/block_storage/mod.rs
@@ -15,10 +15,8 @@
 //! Block Storage API implementation bits.
 
 mod api;
-mod volumes;
 mod protocol;
+mod volumes;
 
+pub use self::protocol::{VolumeSortKey, VolumeStatus};
 pub use self::volumes::{Volume, VolumeQuery};
-pub use self::protocol::{
-    VolumeSortKey, VolumeStatus,
-};

--- a/src/block_storage/mod.rs
+++ b/src/block_storage/mod.rs
@@ -19,4 +19,4 @@ mod protocol;
 mod volumes;
 
 pub use self::protocol::{VolumeSortKey, VolumeStatus};
-pub use self::volumes::{Volume, VolumeQuery};
+pub use self::volumes::{Volume, VolumeQuery, NewVolume};

--- a/src/block_storage/mod.rs
+++ b/src/block_storage/mod.rs
@@ -18,5 +18,5 @@ mod api;
 mod protocol;
 mod volumes;
 
-pub use self::protocol::{VolumeSortKey, VolumeStatus};
+pub use self::protocol::{VolumeAttachment, VolumeSortKey, VolumeStatus};
 pub use self::volumes::{NewVolume, Volume, VolumeQuery};

--- a/src/block_storage/mod.rs
+++ b/src/block_storage/mod.rs
@@ -19,4 +19,4 @@ mod protocol;
 mod volumes;
 
 pub use self::protocol::{VolumeSortKey, VolumeStatus};
-pub use self::volumes::{Volume, VolumeQuery, NewVolume};
+pub use self::volumes::{NewVolume, Volume, VolumeQuery};

--- a/src/block_storage/mod.rs
+++ b/src/block_storage/mod.rs
@@ -15,4 +15,10 @@
 //! Block Storage API implementation bits.
 
 mod api;
+mod volumes;
 mod protocol;
+
+pub use self::volumes::{Volume, VolumeQuery};
+pub use self::protocol::{
+    VolumeSortKey, VolumeStatus,
+};

--- a/src/block_storage/mod.rs
+++ b/src/block_storage/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2024 Sandro-Alessio Gierens <sandro@gierens.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Block Storage API implementation bits.
+
+mod api;
+mod protocol;

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -64,7 +64,6 @@ impl Default for VolumeSortKey {
 
 /// A volume attachment.
 #[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
 pub struct VolumeAttachment {
     pub server_id: String, // this should be a reference to a server
     pub attachment_id: String,
@@ -76,7 +75,6 @@ pub struct VolumeAttachment {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
 pub struct Link {
     pub rel: String,
     pub href: String,
@@ -84,7 +82,6 @@ pub struct Link {
 
 /// A volume.
 #[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
 pub struct Volume {
     // TODO: not all fields fully match the API spec:
     // https://docs.openstack.org/api-ref/block-storage/v3/#list-accessible-volumes-with-details

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -17,7 +17,7 @@
 #![allow(non_snake_case)]
 #![allow(missing_docs)]
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 protocol_enum! {
@@ -144,4 +144,55 @@ pub struct VolumeRoot {
 #[derive(Debug, Clone, Deserialize)]
 pub struct VolumesRoot {
     pub volumes: Vec<Volume>,
+}
+
+/// Volume arguments for a create request.
+#[derive(Debug, Clone, Serialize)]
+pub struct VolumeCreate {
+    pub size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub availability_zone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "source_volid")]
+    pub source_volume_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backup_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "imageRef")]
+    pub image_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "consistency_group_id")]
+    pub consistency_group_id: Option<String>,
+}
+
+/// A volume create request.
+#[derive(Clone, Debug, Serialize)]
+pub struct VolumeCreateRoot {
+    pub volume: VolumeCreate,
+    // NOTE: this can also contain a scheduler_hints field
+}
+
+impl VolumeCreate {
+    pub fn new(size: u64) -> VolumeCreate {
+        VolumeCreate {
+            size,
+            availability_zone: None,
+            source_volume_id: None,
+            description: None,
+            snapshot_id: None,
+            backup_id: None,
+            name: None,
+            image_id: None,
+            volume_type: None,
+            metadata: None,
+            consistency_group_id: None,
+        }
+    }
 }

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -17,8 +17,8 @@
 #![allow(non_snake_case)]
 #![allow(missing_docs)]
 
-use std::collections::HashMap;
 use serde::Deserialize;
+use std::collections::HashMap;
 
 protocol_enum! {
     #[doc = "Possible volume statuses."]
@@ -123,7 +123,7 @@ pub struct Volume {
     pub bootable: String,
     pub created_at: String,
     pub volumes: Option<Vec<Volume>>, // not optional in spec
-    pub volume_type: String, // consider enum
+    pub volume_type: String,          // consider enum
     pub volume_type_id: Option<HashMap<String, String>>, // not optional in spec
     pub group_id: Option<String>,
     pub volumes_links: Option<Vec<String>>,

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -19,8 +19,6 @@
 
 use serde::Deserialize;
 
-// use super::super::common;
-
 protocol_enum! {
     #[doc = "Possible volume statuses."]
     enum VolumeStatus {

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -16,7 +16,7 @@
 
 #![allow(missing_docs)]
 
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserializer, Deserialize, Serialize};
 use std::collections::HashMap;
 
 protocol_enum! {
@@ -77,6 +77,20 @@ pub struct VolumeAttachment {
 pub struct Link {
     pub rel: String,
     pub href: String,
+}
+
+fn bool_from_bootable_string<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match String::deserialize(deserializer)?.as_ref() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        other => Err(de::Error::invalid_value(
+            de::Unexpected::Str(other),
+            &"true or false",
+        )),
+    }
 }
 
 /// A volume.

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -168,7 +168,10 @@ pub struct VolumeCreate {
     pub volume_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "consistency_group_id")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "consistency_group_id"
+    )]
     pub consistency_group_id: Option<String>,
 }
 

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -16,7 +16,7 @@
 
 #![allow(missing_docs)]
 
-use serde::{de, Deserializer, Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
 protocol_enum! {
@@ -136,7 +136,8 @@ pub struct Volume {
     #[serde(rename = "os-vol-mig-status-attr:name_id")]
     pub name_id: Option<String>,
     pub name: String,
-    pub bootable: String,
+    #[serde(deserialize_with = "bool_from_bootable_string")]
+    pub bootable: bool,
     pub created_at: String,
     pub volumes: Option<Vec<Volume>>, // not optional in spec
     pub volume_type: String,          // consider enum

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -111,7 +111,8 @@ pub struct Volume {
     #[serde(rename = "volume_image_metadata")]
     pub image_metadata: Option<HashMap<String, String>>,
     pub description: Option<String>,
-    pub multiattach: bool,
+    #[serde(rename = "multiattach")]
+    pub multi_attachable: bool,
     #[serde(rename = "source_volid")]
     pub source_volume_id: Option<String>,
     #[serde(rename = "consistencygroup_id")]

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -14,7 +14,6 @@
 
 //! JSON structures and protocol bits for the Block Storage API.
 
-#![allow(non_snake_case)]
 #![allow(missing_docs)]
 
 use serde::{Deserialize, Serialize};

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -62,3 +62,23 @@ impl Default for VolumeSortKey {
         VolumeSortKey::CreatedAt
     }
 }
+
+/// A volume.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Volume {
+    pub id: String,
+    pub name: String,
+    pub status: VolumeStatus,
+}
+
+/// A volume root.
+#[derive(Clone, Debug, Deserialize)]
+pub struct VolumeRoot {
+    pub volume: Volume,
+}
+
+/// A list of volumes.
+#[derive(Debug, Clone, Deserialize)]
+pub struct VolumesRoot {
+    pub volumes: Vec<Volume>,
+}

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -13,3 +13,52 @@
 // limitations under the License.
 
 //! JSON structures and protocol bits for the Block Storage API.
+
+#![allow(non_snake_case)]
+#![allow(missing_docs)]
+
+use serde::Deserialize;
+
+// use super::super::common;
+
+protocol_enum! {
+    #[doc = "Possible volume statuses."]
+    enum VolumeStatus {
+        Creating = "creating",
+        Available = "available",
+        Reserved = "reserved",
+        Attaching = "attaching",
+        Detaching = "detaching",
+        InUse = "in-use",
+        Maintenance = "maintenance",
+        Deleting = "deleting",
+        AwaitingTransfer = "awaiting-transfer",
+        Error = "error",
+        ErrorDeleting = "error_deleting",
+        BackingUp = "backing-up",
+        RestoringBackup = "restoring-backup",
+        ErrorBackingUp = "error_backing-up",
+        ErrorRestoring = "error_restoring",
+        ErrorExtending = "error_extending",
+        Downloading = "downloading",
+        Uploading = "uploading",
+        Retyping = "retyping",
+        Extending = "extending"
+    }
+}
+
+protocol_enum! {
+    #[doc = "Available sort keys."]
+    enum VolumeSortKey {
+        CreatedAt = "created_at",
+        Id = "id",
+        Name = "name",
+        UpdatedAt = "updated_at"
+    }
+}
+
+impl Default for VolumeSortKey {
+    fn default() -> VolumeSortKey {
+        VolumeSortKey::CreatedAt
+    }
+}

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -103,8 +103,11 @@ pub struct Volume {
     pub user_id: String,
     #[serde(rename = "os-vol-tenant-attr:tenant_id")]
     pub tenant_id: Option<String>,
-    #[serde(rename = "os-vol-mig-status-attr:migstat")]
-    pub migstat: Option<String>, // consider enum
+    // The naming of this field is a little unintuitive and we are not actually
+    // sure what it does or how it is different from the migration_status field.
+    // So we skip it.
+    // #[serde(rename = "os-vol-mig-status-attr:migstat")]
+    // pub migstat: Option<String>, // consider enum
     pub metadata: HashMap<String, String>,
     pub status: VolumeStatus,
     #[serde(rename = "volume_image_metadata")]

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -177,7 +177,7 @@ pub struct Volume {
     pub host: Option<String>,
     pub encrypted: bool,
     pub encryption_key_id: Option<String>,
-    pub updated_at: Option<String>,
+    pub updated_at: Option<DateTime>,
     pub replication_status: Option<String>, // not optional in spec, also consider enum
     pub snapshot_id: Option<String>,
     pub id: String,
@@ -206,7 +206,7 @@ pub struct Volume {
     pub name: String,
     #[serde(deserialize_with = "bool_from_bootable_string")]
     pub bootable: bool,
-    pub created_at: String,
+    pub created_at: DateTime,
     pub volumes: Option<Vec<Volume>>, // not optional in spec
     pub volume_type: String,          // consider enum
     pub volume_type_id: Option<HashMap<String, String>>, // not optional in spec

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -96,24 +96,26 @@ pub struct Volume {
     pub host: Option<String>,
     pub encrypted: bool,
     pub encryption_key_id: Option<String>,
-    pub updated_at: String,
+    pub updated_at: Option<String>,
     pub replication_status: Option<String>, // not optional in spec, also consider enum
     pub snapshot_id: Option<String>,
     pub id: String,
     pub size: u64,
     pub user_id: String,
     #[serde(rename = "os-vol-tenant-attr:tenant_id")]
-    pub tenant_id: String,
+    pub tenant_id: Option<String>,
     #[serde(rename = "os-vol-mig-status-attr:migstat")]
     pub migstat: Option<String>, // consider enum
     pub metadata: HashMap<String, String>,
     pub status: VolumeStatus,
     #[serde(rename = "volume_image_metadata")]
     pub image_metadata: Option<HashMap<String, String>>,
-    pub description: String,
+    pub description: Option<String>,
     pub multiattach: bool,
-    pub source_volid: Option<String>,
-    pub consistencygroup_id: Option<String>, // not optional in spec
+    #[serde(rename = "source_volid")]
+    pub source_volume_id: Option<String>,
+    #[serde(rename = "consistencygroup_id")]
+    pub consistency_group_id: Option<String>, // not optional in spec
     #[serde(rename = "os-vol-mig-status-attr:name_id")]
     pub name_id: Option<String>,
     pub name: String,

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -61,6 +61,26 @@ impl Default for VolumeSortKey {
     }
 }
 
+/// A volume attachment.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct VolumeAttachment {
+    pub server_id: String, // this should be a reference to a server
+    pub attachment_id: String,
+    pub attached_at: String,
+    pub host_name: String,
+    pub volume_id: String, // this should be a reference to a volume
+    pub device: String,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct Link {
+    pub rel: String,
+    pub href: String,
+}
+
 /// A volume.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Volume {

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -128,7 +128,8 @@ pub struct Volume {
     pub group_id: Option<String>,
     pub volumes_links: Option<Vec<String>>,
     pub provider_id: Option<String>,
-    pub service_uuid: Option<String>, // not optional in spec
+    #[serde(rename = "service_uuid")]
+    pub service_id: Option<String>, // not optional in spec
     pub shared_targets: Option<bool>, // not optional in spec
     pub cluster_name: Option<String>,
     pub consumes_quota: Option<bool>,

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -63,6 +63,7 @@ impl Default for VolumeSortKey {
 
 /// A volume attachment.
 #[derive(Debug, Clone, Deserialize)]
+#[non_exhaustive]
 pub struct VolumeAttachment {
     pub server_id: String, // this should be a reference to a server
     pub attachment_id: String,

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -161,8 +161,7 @@ pub struct VolumeCreate {
     pub snapshot_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String, // not optional in spec, but doesn't work with None/null, only with ""
     #[serde(skip_serializing_if = "Option::is_none", rename = "imageRef")]
     pub image_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -192,7 +191,7 @@ impl VolumeCreate {
             description: None,
             snapshot_id: None,
             backup_id: None,
-            name: None,
+            name: "".to_string(),
             image_id: None,
             volume_type: None,
             metadata: None,

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -17,6 +17,7 @@
 #![allow(non_snake_case)]
 #![allow(missing_docs)]
 
+use std::collections::HashMap;
 use serde::Deserialize;
 
 protocol_enum! {
@@ -83,10 +84,55 @@ pub struct Link {
 
 /// A volume.
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct Volume {
+    // TODO: not all fields fully match the API spec:
+    // https://docs.openstack.org/api-ref/block-storage/v3/#list-accessible-volumes-with-details
+    // Some fields are not actually optional, but don't work without Option<>.
+    // Others should maybe be enums, but the possible values are not documented.
+    // There are comments for these cases.
+    pub migration_status: Option<String>, // consider enum
+    pub attachments: Vec<VolumeAttachment>,
+    pub links: Vec<Link>,
+    pub availability_zone: Option<String>,
+    #[serde(rename = "os-vol-host-attr:host")]
+    pub host: Option<String>,
+    pub encrypted: bool,
+    pub encryption_key_id: Option<String>,
+    pub updated_at: String,
+    pub replication_status: Option<String>, // not optional in spec, also consider enum
+    pub snapshot_id: Option<String>,
     pub id: String,
-    pub name: String,
+    pub size: u64,
+    pub user_id: String,
+    #[serde(rename = "os-vol-tenant-attr:tenant_id")]
+    pub tenant_id: String,
+    #[serde(rename = "os-vol-mig-status-attr:migstat")]
+    pub migstat: Option<String>, // consider enum
+    pub metadata: HashMap<String, String>,
     pub status: VolumeStatus,
+    #[serde(rename = "volume_image_metadata")]
+    pub image_metadata: Option<HashMap<String, String>>,
+    pub description: String,
+    pub multiattach: bool,
+    pub source_volid: Option<String>,
+    pub consistencygroup_id: Option<String>, // not optional in spec
+    #[serde(rename = "os-vol-mig-status-attr:name_id")]
+    pub name_id: Option<String>,
+    pub name: String,
+    pub bootable: String,
+    pub created_at: String,
+    pub volumes: Option<Vec<Volume>>, // not optional in spec
+    pub volume_type: String, // consider enum
+    pub volume_type_id: Option<HashMap<String, String>>, // not optional in spec
+    pub group_id: Option<String>,
+    pub volumes_links: Option<Vec<String>>,
+    pub provider_id: Option<String>,
+    pub service_uuid: Option<String>, // not optional in spec
+    pub shared_targets: Option<bool>, // not optional in spec
+    pub cluster_name: Option<String>,
+    pub consumes_quota: Option<bool>,
+    pub count: Option<u64>,
 }
 
 /// A volume root.

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -1,0 +1,15 @@
+// Copyright 2024 Sandro-Alessio Gierens <sandro@gierens.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! JSON structures and protocol bits for the Block Storage API.

--- a/src/block_storage/protocol.rs
+++ b/src/block_storage/protocol.rs
@@ -67,7 +67,7 @@ pub struct VolumeAttachment {
     pub server_id: String, // this should be a reference to a server
     pub attachment_id: String,
     pub attached_at: String,
-    pub host_name: String,
+    pub host_name: Option<String>,
     pub volume_id: String, // this should be a reference to a volume
     pub device: String,
     pub id: String,

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -74,11 +74,6 @@ impl Volume {
     }
 
     transparent_property! {
-        #[doc = "Volume links."]
-        links: ref Vec<protocol::Link>
-    }
-
-    transparent_property! {
         #[doc = "Name of the availability zone."]
         availability_zone: ref Option<String>
     }
@@ -211,11 +206,6 @@ impl Volume {
     transparent_property! {
         #[doc = "UUID of the group."]
         group_id: ref Option<String>
-    }
-
-    transparent_property! {
-        #[doc = "A list of volume links."]
-        volumes_links: ref Option<Vec<String>>
     }
 
     transparent_property! {

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use futures::stream::{Stream, TryStreamExt};
 use std::fmt::{self, Display, Formatter};
 use std::time::Duration;
+use std::collections::HashMap;
 
 use super::super::common::{Refresh, ResourceIterator, ResourceQuery};
 use super::super::session::Session;
@@ -40,6 +41,13 @@ pub struct VolumeQuery {
 pub struct Volume {
     session: Session,
     inner: protocol::Volume,
+}
+
+/// A request to create a volume.
+#[derive(Clone, Debug)]
+pub struct NewVolume {
+    session: Session,
+    inner: protocol::VolumeCreate,
 }
 
 impl Display for Volume {
@@ -197,5 +205,74 @@ impl ResourceQuery for VolumeQuery {
                 inner: item,
             })
             .collect())
+    }
+}
+
+impl NewVolume {
+    /// Start creating a volume.
+    pub(crate) fn new(session: Session, size: u64) -> NewVolume {
+        NewVolume {
+            session,
+            inner: protocol::VolumeCreate::new(size),
+        }
+    }
+
+    /// Request creation of the volume.
+    pub async fn create(self) -> Result<Volume> {
+        let inner = api::create_volume(&self.session, self.inner).await?;
+        Ok(Volume {
+            session: self.session,
+            inner,
+        })
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the availability zone."]
+        set_availability_zone, with_availability_zone -> availability_zone: optional String
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the source volume ID."]
+        set_source_volume_id, with_source_volume_id -> source_volume_id: optional String
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the description."]
+        set_description, with_description -> description: optional String
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the snapshot ID."]
+        set_snapshot_id, with_snapshot_id -> snapshot_id: optional String
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the backup ID."]
+        set_backup_id, with_backup_id -> backup_id: optional String
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the name."]
+        set_name, with_name -> name: optional String
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the image ID."]
+        set_image_id, with_image_id -> image_id: optional String
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the volume type."]
+        set_volume_type, with_volume_type -> volume_type: optional String
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the metadata."]
+        set_metadata, with_metadata -> metadata: optional HashMap<String, String>
+    }
+
+    creation_inner_field! {
+        #[doc = "Set the consistency group ID."]
+        set_consistency_group_id, with_consistency_group_id -> consistency_group_id: optional String
     }
 }

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -175,7 +175,7 @@ impl Volume {
 
     transparent_property! {
         #[doc = "Whether the volume is bootable."]
-        bootable: ref String
+        bootable: bool
     }
 
     transparent_property! {

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -16,6 +16,7 @@
 
 use async_trait::async_trait;
 use futures::stream::{Stream, TryStreamExt};
+use std::fmt::{self, Display, Formatter};
 
 use super::super::common::{Refresh, ResourceIterator, ResourceQuery};
 use super::super::session::Session;
@@ -37,6 +38,12 @@ pub struct VolumeQuery {
 pub struct Volume {
     session: Session,
     inner: protocol::Volume,
+}
+
+impl Display for Volume {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#?}", self.inner)
+    }
 }
 
 impl Volume {

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -64,13 +64,188 @@ impl Volume {
     }
 
     transparent_property! {
-        #[doc = "Unique ID."]
+        #[doc = "Migration status."]
+        migration_status: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Volume attachments."]
+        attachments: ref Vec<protocol::VolumeAttachment>
+    }
+
+    transparent_property! {
+        #[doc = "Volume links."]
+        links: ref Vec<protocol::Link>
+    }
+
+    transparent_property! {
+        #[doc = "Name of the availability zone."]
+        availability_zone: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Current backend of the volume."]
+        host: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Whether the volume is encrypted."]
+        encrypted: ref bool
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the encryption key."]
+        encryption_key_id: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "When the volume was last updated."]
+        updated_at: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Volume replication status."]
+        replication_status: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the snapshot the volume originated from."]
+        snapshot_id: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the volume."]
         id: ref String
     }
 
     transparent_property! {
-        #[doc = "Volume name."]
+        #[doc = "Size of the volume in GiB."]
+        size: ref u64
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the user."]
+        user_id: ref String
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the project."]
+        tenant_id: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Migration status."]
+        migstat: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Metadata of the volume."]
+        metadata: ref HashMap<String, String>
+    }
+
+    transparent_property! {
+        #[doc = "Status of the volume."]
+        status: ref protocol::VolumeStatus
+    }
+
+    transparent_property! {
+        #[doc = "Metadata of the image used to create the volume."]
+        image_metadata: ref Option<HashMap<String, String>>
+    }
+
+    transparent_property! {
+        #[doc = "Description of the volume."]
+        description: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Whether the volume is multi-attachable."]
+        multi_attachable: ref bool
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the volume this one originated from."]
+        source_volume_id: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the consistency group."]
+        consistency_group_id: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the volume that this volume name on the backend is based on."]
+        name_id: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Name of the volume."]
         name: ref String
+    }
+
+    transparent_property! {
+        #[doc = "Whether the volume is bootable."]
+        bootable: ref String
+    }
+
+    transparent_property! {
+        #[doc = "When the volume was created."]
+        created_at: ref String
+    }
+
+    transparent_property! {
+        #[doc = "A list of volume objects."]
+        volumes: ref Option<Vec<protocol::Volume>>
+    }
+
+    transparent_property! {
+        #[doc = "Name of the volume type."]
+        volume_type: ref String
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the volume type."]
+        volume_type_id: ref Option<HashMap<String, String>>
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the group."]
+        group_id: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "A list of volume links."]
+        volumes_links: ref Option<Vec<String>>
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the provider for the volume."]
+        provider_id: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "UUID of the service the volume is served on."]
+        service_uuid: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Whether the volume has shared targets."]
+        shared_targets: ref Option<bool>
+    }
+
+    transparent_property! {
+        #[doc = "Cluster name of the volume backend."]
+        cluster_name: ref Option<String>
+    }
+
+    transparent_property! {
+        #[doc = "Whether the volume consumes quota."]
+        consumes_quota: ref Option<bool>
+    }
+
+    transparent_property! {
+        #[doc = "Total count of volumes requested before pagination."]
+        count: ref Option<u64>
     }
 
     /// Delete the volume.

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -1,0 +1,49 @@
+// Copyright 2024 Sandro-Alessio Gierens <sandro@gierens.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Volume management via Block Storage API.
+
+use async_trait::async_trait;
+use futures::stream::{Stream, TryStreamExt};
+
+use super::super::common::{Refresh, ResourceIterator, ResourceQuery};
+use super::super::session::Session;
+use super::super::utils::Query;
+use super::super::{Result, Sort};
+use super::{api, protocol};
+
+/// Structure representing a summary of a single volume.
+#[derive(Clone, Debug)]
+pub struct Volume {
+    session: Session,
+    inner: protocol::Volume,
+}
+
+impl Volume {
+    /// Create an Volume object.
+    pub(crate) async fn new<Id: AsRef<str>>(session: Session, id: Id) -> Result<Volume> {
+        let inner = api::get_volume(&session, id).await?;
+        Ok(Volume { session, inner })
+    }
+
+    transparent_property! {
+        #[doc = "Unique ID."]
+        id: ref String
+    }
+
+    transparent_property! {
+        #[doc = "Volume name."]
+        name: ref String
+    }
+}

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -17,8 +17,10 @@
 use async_trait::async_trait;
 use futures::stream::{Stream, TryStreamExt};
 use std::fmt::{self, Display, Formatter};
+use std::time::Duration;
 
 use super::super::common::{Refresh, ResourceIterator, ResourceQuery};
+use super::super::waiter::DeletionWaiter;
 use super::super::session::Session;
 use super::super::utils::Query;
 use super::super::{Result, Sort};
@@ -61,6 +63,16 @@ impl Volume {
     transparent_property! {
         #[doc = "Volume name."]
         name: ref String
+    }
+
+    /// Delete the volume.
+    pub async fn delete(self) -> Result<DeletionWaiter<Volume>> {
+        api::delete_volume(&self.session, &self.inner.id).await?;
+        Ok(DeletionWaiter::new(
+            self,
+            Duration::new(120, 0),
+            Duration::new(1, 0),
+        ))
     }
 }
 

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -129,11 +129,6 @@ impl Volume {
     }
 
     transparent_property! {
-        #[doc = "Migration status."]
-        migstat: ref Option<String>
-    }
-
-    transparent_property! {
         #[doc = "Metadata of the volume."]
         metadata: ref HashMap<String, String>
     }

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -90,7 +90,7 @@ impl Volume {
 
     transparent_property! {
         #[doc = "Whether the volume is encrypted."]
-        encrypted: ref bool
+        encrypted: bool
     }
 
     transparent_property! {
@@ -120,7 +120,7 @@ impl Volume {
 
     transparent_property! {
         #[doc = "Size of the volume in GiB."]
-        size: ref u64
+        size: u64
     }
 
     transparent_property! {
@@ -145,7 +145,7 @@ impl Volume {
 
     transparent_property! {
         #[doc = "Status of the volume."]
-        status: ref protocol::VolumeStatus
+        status: protocol::VolumeStatus
     }
 
     transparent_property! {
@@ -160,7 +160,7 @@ impl Volume {
 
     transparent_property! {
         #[doc = "Whether the volume is multi-attachable."]
-        multi_attachable: ref bool
+        multi_attachable: bool
     }
 
     transparent_property! {
@@ -230,7 +230,7 @@ impl Volume {
 
     transparent_property! {
         #[doc = "Whether the volume has shared targets."]
-        shared_targets: ref Option<bool>
+        shared_targets: Option<bool>
     }
 
     transparent_property! {
@@ -240,12 +240,12 @@ impl Volume {
 
     transparent_property! {
         #[doc = "Whether the volume consumes quota."]
-        consumes_quota: ref Option<bool>
+        consumes_quota: Option<bool>
     }
 
     transparent_property! {
         #[doc = "Total count of volumes requested before pagination."]
-        count: ref Option<u64>
+        count: Option<u64>
     }
 
     /// Delete the volume.

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -95,7 +95,7 @@ impl Volume {
 
     transparent_property! {
         #[doc = "When the volume was last updated."]
-        updated_at: ref Option<String>
+        updated_at: Option<protocol::DateTime>
     }
 
     transparent_property! {
@@ -180,7 +180,7 @@ impl Volume {
 
     transparent_property! {
         #[doc = "When the volume was created."]
-        created_at: ref String
+        created_at: protocol::DateTime
     }
 
     transparent_property! {

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -47,3 +47,12 @@ impl Volume {
         name: ref String
     }
 }
+
+#[async_trait]
+impl Refresh for Volume {
+    /// Refresh the volume.
+    async fn refresh(&mut self) -> Result<()> {
+        self.inner = api::get_volume_by_id(&self.session, &self.inner.id).await?;
+        Ok(())
+    }
+}

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -20,9 +20,9 @@ use std::fmt::{self, Display, Formatter};
 use std::time::Duration;
 
 use super::super::common::{Refresh, ResourceIterator, ResourceQuery};
-use super::super::waiter::DeletionWaiter;
 use super::super::session::Session;
 use super::super::utils::Query;
+use super::super::waiter::DeletionWaiter;
 use super::super::{Result, Sort};
 use super::{api, protocol};
 

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -428,7 +428,7 @@ impl NewVolume {
 
     creation_inner_field! {
         #[doc = "Set the name."]
-        set_name, with_name -> name: optional String
+        set_name, with_name -> name: String
     }
 
     creation_inner_field! {

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -225,7 +225,7 @@ impl Volume {
 
     transparent_property! {
         #[doc = "UUID of the service the volume is served on."]
-        service_uuid: ref Option<String>
+        service_id: ref Option<String>
     }
 
     transparent_property! {

--- a/src/block_storage/volumes.rs
+++ b/src/block_storage/volumes.rs
@@ -16,9 +16,9 @@
 
 use async_trait::async_trait;
 use futures::stream::{Stream, TryStreamExt};
+use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
 use std::time::Duration;
-use std::collections::HashMap;
 
 use super::super::common::{Refresh, ResourceIterator, ResourceQuery};
 use super::super::session::Session;

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -21,7 +21,7 @@ use std::io;
 
 use super::auth::AuthType;
 #[cfg(feature = "block-storage")]
-use super::block_storage::{Volume, VolumeQuery, NewVolume};
+use super::block_storage::{NewVolume, Volume, VolumeQuery};
 #[allow(unused_imports)]
 use super::common::{ContainerRef, FlavorRef, NetworkRef};
 #[cfg(feature = "compute")]

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -768,6 +768,7 @@ impl Cloud {
     }
 
     /// List all volumes.
+    #[cfg(feature = "block-storage")]
     pub async fn list_volumes(&self) -> Result<Vec<Volume>> {
         self.find_volumes().all().await
     }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -22,6 +22,8 @@ use std::io;
 use super::auth::AuthType;
 #[allow(unused_imports)]
 use super::common::{ContainerRef, FlavorRef, NetworkRef};
+#[cfg(feature = "block-storage")]
+use super::block_storage::{Volume, VolumeQuery};
 #[cfg(feature = "compute")]
 use super::compute::{
     Flavor, FlavorQuery, FlavorSummary, KeyPair, KeyPairQuery, NewKeyPair, NewServer, Server,
@@ -308,6 +310,15 @@ impl Cloud {
     #[cfg(feature = "network")]
     pub fn find_subnets(&self) -> SubnetQuery {
         SubnetQuery::new(self.session.clone())
+    }
+
+    /// Build a query against volume list.
+    ///
+    /// The returned object is a builder that should be used to construct
+    /// the query.
+    #[cfg(feature = "block-storage")]
+    pub fn find_volumes(&self) -> VolumeQuery {
+        VolumeQuery::new(self.session.clone())
     }
 
     /// Get object container metadata by its name.

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -520,6 +520,23 @@ impl Cloud {
         Subnet::load(self.session.clone(), id_or_name).await
     }
 
+    /// Find an volume by its name or ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use openstack;
+    ///
+    /// # async fn async_wrapper() {
+    /// let os = openstack::Cloud::from_env().await.expect("Unable to authenticate");
+    /// let volume = os.get_volume("my-first-volume").await.expect("Unable to get a volume");
+    /// # }
+    /// ```
+    #[cfg(feature = "block-storage")]
+    pub async fn get_volume<Id: AsRef<str>>(&self, id_or_name: Id) -> Result<Volume> {
+        Volume::new(self.session.clone(), id_or_name).await
+    }
+
     /// List all containers.
     ///
     /// This call can yield a lot of results, use the

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -20,10 +20,10 @@ use futures::io::AsyncRead;
 use std::io;
 
 use super::auth::AuthType;
-#[allow(unused_imports)]
-use super::common::{ContainerRef, FlavorRef, NetworkRef};
 #[cfg(feature = "block-storage")]
 use super::block_storage::{Volume, VolumeQuery};
+#[allow(unused_imports)]
+use super::common::{ContainerRef, FlavorRef, NetworkRef};
 #[cfg(feature = "compute")]
 use super::compute::{
     Flavor, FlavorQuery, FlavorSummary, KeyPair, KeyPairQuery, NewKeyPair, NewServer, Server,

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -750,6 +750,11 @@ impl Cloud {
         self.find_subnets().all().await
     }
 
+    /// List all volumes.
+    pub async fn list_volumes(&self) -> Result<Vec<Volume>> {
+        self.find_volumes().all().await
+    }
+
     /// Prepare a new object for creation.
     ///
     /// This call returns a `NewObject` object, which is a builder

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -21,7 +21,7 @@ use std::io;
 
 use super::auth::AuthType;
 #[cfg(feature = "block-storage")]
-use super::block_storage::{Volume, VolumeQuery};
+use super::block_storage::{Volume, VolumeQuery, NewVolume};
 #[allow(unused_imports)]
 use super::common::{ContainerRef, FlavorRef, NetworkRef};
 #[cfg(feature = "compute")]
@@ -852,6 +852,18 @@ impl Cloud {
         F: Into<FlavorRef>,
     {
         NewServer::new(self.session.clone(), name.into(), flavor.into())
+    }
+
+    /// Prepare a new volume for creation.
+    ///
+    /// This call returns a `NewVolume` object, which is a builder to populate
+    /// volume fields.
+    #[cfg(feature = "block-storage")]
+    pub fn new_volume<U>(&self, size: U) -> NewVolume
+    where
+        U: Into<u64>,
+    {
+        NewVolume::new(self.session.clone(), size.into())
     }
 
     /// Prepare a new subnet for creation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,6 +644,8 @@ pub mod auth {
 }
 mod cloud;
 pub mod common;
+#[cfg(feature = "block-storage")]
+pub mod block_storage;
 #[cfg(feature = "compute")]
 pub mod compute;
 #[cfg(feature = "image")]
@@ -652,8 +654,6 @@ pub mod image;
 pub mod network;
 #[cfg(feature = "object-storage")]
 pub mod object_storage;
-#[cfg(feature = "block-storage")]
-pub mod block_storage;
 /// Synchronous sessions based on one from [osauth](https://docs.rs/osauth/).
 pub mod session {
     pub use osauth::services::ServiceType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,6 +652,8 @@ pub mod image;
 pub mod network;
 #[cfg(feature = "object-storage")]
 pub mod object_storage;
+#[cfg(feature = "block-storage")]
+pub mod block_storage;
 /// Synchronous sessions based on one from [osauth](https://docs.rs/osauth/).
 pub mod session {
     pub use osauth::services::ServiceType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -642,10 +642,10 @@ pub mod auth {
     pub use osauth::identity::{Password, Scope, Token};
     pub use osauth::{AuthType, NoAuth};
 }
-mod cloud;
-pub mod common;
 #[cfg(feature = "block-storage")]
 pub mod block_storage;
+mod cloud;
+pub mod common;
 #[cfg(feature = "compute")]
 pub mod compute;
 #[cfg(feature = "image")]

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -1,0 +1,49 @@
+// Copyright 2024 Sandro-Alessio Gierens <sandro@gierens.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+
+async fn set_up() -> openstack::Cloud {
+    INIT.call_once(|| {
+        env_logger::init();
+    });
+
+    openstack::Cloud::from_env()
+        .await
+        .expect("Failed to create an identity provider from the environment")
+}
+
+#[tokio::test]
+async fn test_volume_create_get_delete_simple() {
+    let os = set_up().await;
+
+    let volume = os
+        .new_volume(1 as u64)
+        .create()
+        .await
+        .expect("Could not create volume");
+    let id = volume.id().clone();
+    assert_eq!(volume.name(), "");
+    assert_eq!(*volume.size(), 1 as u64);
+
+    let volume2 = os.get_volume(&id).await.expect("Could not get volume");
+    assert_eq!(volume2.id(), volume.id());
+
+    volume.delete().await.expect("Could not delete volume");
+
+    let volume3 = os.get_volume(id).await;
+    assert!(volume3.is_err());
+}

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -38,7 +38,7 @@ async fn test_volume_create_get_delete_simple() {
     let id = volume.id().clone();
     assert!(volume.name().is_empty());
     assert!(volume.description().is_none());
-    assert_eq!(*volume.size(), 1 as u64);
+    assert_eq!(volume.size(), 1 as u64);
 
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     let volume2 = os.get_volume(&id).await.expect("Could not get volume");
@@ -64,7 +64,7 @@ async fn test_volume_create_with_fields() {
         .expect("Could not create volume");
     assert_eq!(volume.name(), "test_volume");
     assert_eq!(*volume.description(), Some("test_description".to_string()));
-    assert_eq!(*volume.size(), 1 as u64);
+    assert_eq!(volume.size(), 1 as u64);
 
     volume.delete().await.expect("Could not delete volume");
 }

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use openstack::block_storage::VolumeStatus;
 use std::sync::Once;
 
 static INIT: Once = Once::new();

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -56,7 +56,7 @@ async fn test_volume_create_with_fields() {
 
     let volume = os
         .new_volume(1 as u64)
-        .with_name("test_volume")
+        .with_name("test_volume".to_string())
         .with_description("test_description")
         .create()
         .await

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -37,7 +37,7 @@ async fn test_volume_create_get_delete_simple() {
         .await
         .expect("Could not create volume");
     let id = volume.id().clone();
-    assert!(volume.name().is_empty());
+    assert_eq!(*volume.name(), id);
     assert!(volume.description().is_none());
     assert_eq!(*volume.size(), 1 as u64);
 

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -40,11 +40,13 @@ async fn test_volume_create_get_delete_simple() {
     assert!(volume.description().is_none());
     assert_eq!(*volume.size(), 1 as u64);
 
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     let volume2 = os.get_volume(&id).await.expect("Could not get volume");
     assert_eq!(volume2.id(), volume.id());
 
     volume.delete().await.expect("Could not delete volume");
 
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     let volume3 = os.get_volume(id).await;
     assert!(volume3.is_err());
 }

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -36,7 +36,7 @@ async fn test_volume_create_get_delete_simple() {
         .await
         .expect("Could not create volume");
     let id = volume.id().clone();
-    assert_eq!(*volume.name(), id);
+    assert!(volume.name().is_empty());
     assert!(volume.description().is_none());
     assert_eq!(*volume.size(), 1 as u64);
 

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -40,7 +40,6 @@ async fn test_volume_create_get_delete_simple() {
     assert!(volume.name().is_empty());
     assert!(volume.description().is_none());
     assert_eq!(*volume.size(), 1 as u64);
-    assert_eq!(*volume.status(), VolumeStatus::Available);
 
     let volume2 = os.get_volume(&id).await.expect("Could not get volume");
     assert_eq!(volume2.id(), volume.id());
@@ -65,7 +64,6 @@ async fn test_volume_create_with_fields() {
     assert_eq!(volume.name(), "test_volume");
     assert_eq!(*volume.description(), Some("test_description".to_string()));
     assert_eq!(*volume.size(), 1 as u64);
-    assert_eq!(*volume.status(), VolumeStatus::Available);
 
     volume.delete().await.expect("Could not delete volume");
 }

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Once;
 use openstack::block_storage::VolumeStatus;
+use std::sync::Once;
 
 static INIT: Once = Once::new();
 
@@ -49,4 +49,23 @@ async fn test_volume_create_get_delete_simple() {
 
     let volume3 = os.get_volume(id).await;
     assert!(volume3.is_err());
+}
+
+#[tokio::test]
+async fn test_volume_create_with_fields() {
+    let os = set_up().await;
+
+    let volume = os
+        .new_volume(1 as u64)
+        .with_name("test_volume")
+        .with_description("test_description")
+        .create()
+        .await
+        .expect("Could not create volume");
+    assert_eq!(volume.name(), "test_volume");
+    assert_eq!(*volume.description(), Some("test_description".to_string()));
+    assert_eq!(*volume.size(), 1 as u64);
+    assert_eq!(*volume.status(), VolumeStatus::Available);
+
+    volume.delete().await.expect("Could not delete volume");
 }

--- a/tests/integration-block-storage.rs
+++ b/tests/integration-block-storage.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Once;
+use openstack::block_storage::VolumeStatus;
 
 static INIT: Once = Once::new();
 
@@ -36,8 +37,10 @@ async fn test_volume_create_get_delete_simple() {
         .await
         .expect("Could not create volume");
     let id = volume.id().clone();
-    assert_eq!(volume.name(), "");
+    assert!(volume.name().is_empty());
+    assert!(volume.description().is_none());
     assert_eq!(*volume.size(), 1 as u64);
+    assert_eq!(*volume.status(), VolumeStatus::Available);
 
     let volume2 = os.get_volume(&id).await.expect("Could not get volume");
     assert_eq!(volume2.id(), volume.id());

--- a/tests/integration-list-resources.rs
+++ b/tests/integration-list-resources.rs
@@ -82,3 +82,9 @@ async fn test_list_routers() {
     let os = set_up().await;
     let _ = os.list_routers().await.expect("Cannot list routers");
 }
+
+#[tokio::test]
+async fn test_list_volumes() {
+    let os = set_up().await;
+    let _ = os.list_volumes().await.expect("Cannot list volumes");
+}


### PR DESCRIPTION
This starts adding the block storage API alias cinder. So far it implements rudimentary versions of `list_volumes`, `find_volumes` and `get_volume` with an equally minimal `Volume` struct. But I does compile and returns things.

Although the cinder API is very similar to nova's API, this is currently closer to the image module. For example, at the moment it goes directly to the `/volumes/detail` endpoint, rather than defining some kind of `VolumeSummary` for `/volumes` and offering a `detailed()` as the `compute` module does.

This is for simplicity, just to get things rolling. I need this at work, so I can invest a fair bit of time. I'll make it more consistent along the way.