### PR TITLE
Replace Removed Setup Rust Github Action

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout the project
         uses: actions/checkout@v2
       - name: Setup Rust
-        uses: ATiltedTree/setup-rust@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rust-version: stable
       - name: Install ansible


### PR DESCRIPTION
The user account ATiltedTree which hosted the setup-rust action just vanished
from Github. This causes the functional tests to fail. This replaces said
action with actions-rust-lang/setup-rust-toolchain.

Signed-off-by: Sandro-Alessio Gierens <sandro@gierens.de>
