### PR TITLE
Update minimal rust version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, nightly, 1.65.0]
+        rust: [stable, nightly, 1.70.0]
         flags:
           - ""
           - "--no-default-features"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 keywords = ["api", "cloud", "openstack"]
 categories = ["api-bindings"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [features]
 default = ["block-storage", "compute", "image", "network", "native-tls", "object-storage"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //!
 //! # Requirements
 //!
-//! This crate requires Rust 2022 edition and rustc version 1.65.0 or newer.
+//! This crate requires Rust 2022 edition and rustc version 1.70.0 or newer.
 
 #![crate_name = "openstack"]
 #![crate_type = "lib"]


### PR DESCRIPTION
CI seems to be failing on rust 1.65 due to tokio requiring 1.70. Maybe
this crate should also update its minimum version to 1.70. This updates the
version in the `Cargo.toml` and the `lib.rs` docstring and the `main.yml` workflow.
