### PR TITLE
Update OpenStack version in Functional Tests

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -10,14 +10,14 @@ jobs:
         openstack_version: ["master"]
         ubuntu_version: ["22.04"]
         include:
+          - name: "caracal"
+            openstack_version: "stable/2024.1"
+            ubuntu_version: "22.04"
           - name: "bobcat"
             openstack_version: "stable/2023.2"
             ubuntu_version: "22.04"
           - name: "antelope"
             openstack_version: "stable/2023.1"
-            ubuntu_version: "22.04"
-          - name: "zed"
-            openstack_version: "stable/zed"
             ubuntu_version: "22.04"
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Functional tests on OpenStack ${{ matrix.name }}


### PR DESCRIPTION
The OpenStack Zed tests are failing. Since Zed is EOL anyway this simply
removes them and instead adds the new Caracal version to the functional
workflow.
