### PR TITLE
Fix Rust 1.80 cfg Linting and add VolumeRef impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.70"
 default = ["block-storage", "compute", "image", "network", "native-tls", "object-storage"]
 block-storage = []
 compute = []
+identity = [] # reserved for future use
 image = []
 network = []
 native-tls = ["reqwest/default-tls", "osauth/native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,7 @@ tokio = { version = "^1.21", features = ["macros"] }
 [lib]
 name = "openstack"
 path = "src/lib.rs"
+
+[lints.rust]
+# TODO: remove block-storage-snapshot once the snapshot API is implemented
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("block-storage-snapshot", "test"))'] }

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -142,7 +142,7 @@ opaque_resource_type!(#[doc = "An ID of a `Subnet`"] SubnetRef ? "network");
 
 opaque_resource_type!(#[doc = "An ID of a `User`"] UserRef ? "identity");
 
-opaque_resource_type!(#[doc = "An ID of a `Volume`"] VolumeRef ? "volume");
+opaque_resource_type!(#[doc = "An ID of a `Volume`"] VolumeRef ? "block-storage");
 
 #[cfg(test)]
 mod test {

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -136,7 +136,8 @@ opaque_resource_type!(#[doc = "An ID of a `Router`"] RouterRef ? "network");
 
 opaque_resource_type!(#[doc = "An ID of a `SecurityGroup`"] SecurityGroupRef ? "network");
 
-opaque_resource_type!(#[doc = "An ID of a `Snapshot`"] SnapshotRef ? "volume");
+// TODO: change the feature to `block-storage, when the snapshot API is implemented.
+opaque_resource_type!(#[doc = "An ID of a `Snapshot`"] SnapshotRef ? "block-storage-snapshot");
 
 opaque_resource_type!(#[doc = "An ID of a `Subnet`"] SubnetRef ? "network");
 


### PR DESCRIPTION
Rust 1.80 which is used in functional tests does more extensive cfg linting.
Because `volume` and `identity` are not known it causes functional tests to fail.
This adds a linting rule to allow both those values.

For more info see: https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#checked-cfg-names-and-values
